### PR TITLE
fix(local): don't wait on CAPI apps the local provider never renders

### DIFF
--- a/pkg/core/setup_cluster.go
+++ b/pkg/core/setup_cluster.go
@@ -696,8 +696,13 @@ func managementClusterRootChildResources() []*argoCDV1Alpha1.SyncOperationResour
 		constants.ArgoCDAppSealedSecrets,
 		"secrets",
 		"cert-manager",
-		"cluster-api-operator",
-		constants.ArgoCDAppCapiCluster,
+	}
+
+	// The local provider provisions no CAPI cluster, so
+	// getEmbeddedNonSecretTemplateNames omits the cluster-api-operator and
+	// capi-cluster Apps — root never declares them, so don't wait on them.
+	if globals.CloudProviderName != constants.CloudProviderLocal {
+		mgmtApps = append(mgmtApps, "cluster-api-operator", constants.ArgoCDAppCapiCluster)
 	}
 	resources := make([]*argoCDV1Alpha1.SyncOperationResource, 0, len(mgmtApps))
 	for _, name := range mgmtApps {


### PR DESCRIPTION
Closes #12

`managementClusterRootChildResources` hardcoded `cluster-api-operator` + `capi-cluster` in the management-cluster root sync, but `getEmbeddedNonSecretTemplateNames` omits both for the local provider — so root declared 6 children while the sync blocked forever on the 2 local never creates. Skips them for local, matching the existing guards at `setup_cluster.go:237` and `bootstrap_cluster.go:341`.