### PR TITLE
netbird-operator: adopt kubeaid's shared top-level group: structure

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5,29 +5,26 @@ design-stage. Each item states the problem, the options, and a plan.
 
 ## Pending feature work
 
-### Create the mesh DNS zone + groups via the Mgmt API
+### Create the mesh DNS zone via the Mgmt API
 
-The NetBird dashboard steps in `printNetBirdOperatorInstructions`
-(create the mesh DNS zone + the `k8s-<cluster>` group) are manual
-because the kubernetes-operator only *references* those objects
-(`dnsZoneRef.name`, `groups[].name`) — it never creates them.
-Checked 2026-07-03: upstream operator v0.7.0 is current and has no
-issue/PR for creating them; re-check before building this, and drop
-it if the operator gains support.
+The remaining NetBird dashboard step in `printNetBirdOperatorInstructions`
+(create the mesh DNS zone) is manual because the kubernetes-operator only
+*references* the zone (`dnsZoneRef.name`) — it never creates it. The shared
+`k8s-<cluster>` group is no longer manual: the netbird-operator chart now
+provisions it via a Group CR. Checked 2026-07-03: upstream operator v0.7.0
+is current and has no issue/PR for creating DNS zones; re-check before
+building this, and drop it if the operator gains support.
 
 Worse, the instructions box only prints when the
 `netbird-mgmt-api-key` Secret is missing — on the secrets.yaml path
-nobody is told to create the zone/groups at all, and the
-NetworkRouter / NetworkResource CRs sit pending until someone does.
+nobody is told to create the zone at all, and the NetworkRouter /
+NetworkResource CRs sit pending until someone does.
 
 Once the API-key gate passes, kubeaid-cli holds an Admin PAT, so it
-can create them itself. Endpoints verified against Mgmt v0.72.4
+can create the zone itself. Endpoint verified against Mgmt v0.72.4
 (what the kubeaid netbird chart deploys), auth
 `Authorization: Token <PAT>`:
 
-- `GET`/`POST /api/groups` — `{"name": "k8s-<cluster>"}` (the
-  traefik-internal networkResource group) and
-  `{"name": "k8s-<cluster>-admins"}` (clusterProxy RBAC, below)
 - `GET`/`POST /api/dns/zones` — `{"name", "domain",
   "enable_search_domain", "distribution_groups"}`; open question:
   which `distribution_groups` (the `All` group matches a manual
@@ -36,12 +33,12 @@ can create them itself. Endpoints verified against Mgmt v0.72.4
 
 Plan: an idempotent ensure step (list → create when missing) right
 after `awaitNetBirdOperatorToken` returns; on failure warn and print
-the manual dashboard steps instead of aborting a provisioned
-cluster. With group creation in place, also render a default
-clusterProxy RBAC binding `k8s-<cluster>-admins → cluster-admin`
-when `clusterProxy.rbac` is empty (decided 2026-07-03: cluster-admin
-default is fine — group membership is the policy), and trim the
-zone/group steps from the instructions box.
+the manual dashboard step instead of aborting a provisioned cluster.
+The group step has already been trimmed from the instructions box now
+that the chart creates the Group CR. Separately, a default clusterProxy
+RBAC binding `k8s-<cluster>-admins → cluster-admin` when
+`clusterProxy.rbac` is empty is still open (decided 2026-07-03:
+cluster-admin default is fine — group membership is the policy).
 
 ### NetBird operator PAT rotation
 

--- a/pkg/core/netbird/operator_token.go
+++ b/pkg/core/netbird/operator_token.go
@@ -368,16 +368,15 @@ func waitForNetBirdOperatorSecret(
 func printNetBirdOperatorInstructions(netbirdDNS string) {
 	dashboardURL := "https://" + netbirdDNS + "/"
 
-	// The network router references an existing NetBird DNS zone and the
-	// traefik-internal networkResource references a group — both are
-	// dashboard-side (kubeaid-cli only points at them by name), so the
-	// operator has to create them here too.
+	// The network router references an EXISTING NetBird DNS zone by name
+	// (dnsZoneRef) — the operator never creates the zone, so it still has to
+	// be made by hand here. The shared cluster group is no longer listed:
+	// the netbird-operator chart provisions it via a Group CR.
 	cluster := config.ParsedGeneralConfig.Cluster
 	meshDNSZone := ""
 	if cluster.NetBird != nil {
 		meshDNSZone = cluster.NetBird.DNSZone
 	}
-	internalGroup := "k8s-" + cluster.Name
 
 	lines := []string{
 		"",
@@ -398,20 +397,16 @@ func printNetBirdOperatorInstructions(netbirdDNS string) {
 	}
 
 	// Only shown when a mesh DNS zone is set — that's when kubeaid-cli renders
-	// the network router + traefik-internal networkResource that need them.
+	// the network router + traefik-internal networkResource that reference it.
 	//
-	// TODO : create the zone + groups via the Mgmt API once the PAT is in hand
-	// (the operator only references them, it never creates them) — see
-	// docs/TODO.md "Create the mesh DNS zone + groups via the Mgmt API".
+	// TODO : create the mesh DNS zone via the Mgmt API once the PAT is in hand
+	// (the operator only references the zone, it never creates it) — see
+	// docs/TODO.md "Create the mesh DNS zone via the Mgmt API".
 	if meshDNSZone != "" {
 		lines = append(lines,
 			"    4. Sidebar  →  Networks  →  DNS zones  →  + create a DNS zone:",
 			"          Domain:  "+meshDNSZone,
 			"          (the network router publishes exposed Services under it)",
-			"    5. Sidebar  →  Team  →  Groups  →  + create a group:",
-			"          Name:  "+internalGroup,
-			"          (the internal Traefik is exposed to this group — add a",
-			"           NetBird policy granting your peers access to it)",
 		)
 	}
 

--- a/pkg/core/templates.go
+++ b/pkg/core/templates.go
@@ -190,10 +190,14 @@ type TemplateValues struct {
 	// dnsZoneRef. The chart hard-requires the zone, so the router is only
 	// emitted when we have one.
 	NetBirdRouterEnabled bool
-	// NetBirdInternalIngressGroup is the NetBird group the traefik-internal
-	// networkResource is bound to (k8s-<cluster.name>); the operator creates
-	// it in the NetBird dashboard during bootstrap.
-	NetBirdInternalIngressGroup string
+	// NetBirdClusterGroup is the shared NetBird group for this cluster
+	// (k8s-<cluster.name>), rendered as the operator chart's top-level
+	// `group:`. The ClusterProxy peer and the traefik-internal
+	// networkResource both join it, so one NetBird policy targeting the
+	// group grants access to the cluster's kube-API proxy and exposed
+	// Services. The chart provisions the group (Group CR) — it no longer
+	// has to pre-exist in the dashboard.
+	NetBirdClusterGroup string
 
 	// NetBirdAPIKey is secrets.yaml's netbird.apiKey (a Mgmt
 	// service-user access token), sealed into the
@@ -306,11 +310,11 @@ func getTemplateValues(ctx context.Context) *TemplateValues {
 		NetBirdManagementURL: netbirdMgmtURL,
 		NetBirdAPIKey:        corenetbird.APIKey(),
 
-		NetBird:                     netbirdCfg,
-		NetBirdClusterProxyEnabled:  netbirdProxyEnabled,
-		NetBirdOperatorEnabled:      corenetbird.OperatorEnabled(),
-		NetBirdRouterEnabled:        netbirdRouterEnabled,
-		NetBirdInternalIngressGroup: "k8s-" + config.ParsedGeneralConfig.Cluster.Name,
+		NetBird:                    netbirdCfg,
+		NetBirdClusterProxyEnabled: netbirdProxyEnabled,
+		NetBirdOperatorEnabled:     corenetbird.OperatorEnabled(),
+		NetBirdRouterEnabled:       netbirdRouterEnabled,
+		NetBirdClusterGroup:        "k8s-" + config.ParsedGeneralConfig.Cluster.Name,
 
 		CloudflareAPIToken: cloudflareAPIToken(),
 

--- a/pkg/core/templates/argocd-apps/values-netbird-operator.yaml.tmpl
+++ b/pkg/core/templates/argocd-apps/values-netbird-operator.yaml.tmpl
@@ -1,20 +1,29 @@
 {{- /*
 The kubeaid chart wraps the upstream operator: `netbird-operator:` is the
-subchart; networkRouter / networkResources / clusterProxy are top-level
-wrapper values — hence the differing indentation.
+subchart; group / networkRouter / networkResources / clusterProxy are
+top-level wrapper values — hence the differing indentation.
 
 managementURL: cluster.netbird.dns (VPN) or netbird.<base> (workload);
 omitted when underivable — the operator would fall back to NetBird Cloud.
 The API token flows via the netbird-mgmt-api-key Secret, not values.
 
-The router + traefik-internal resource render when a mesh DNS zone is set;
-the zone and k8s-<cluster> group must already exist in NetBird (see
-printNetBirdOperatorInstructions). ClusterProxy is named after cluster.name.
+group is the shared cluster group (k8s-<cluster>): the ClusterProxy and the
+traefik-internal networkResource both join it — the resource omits its own
+`groups` to inherit it — so one NetBird policy on the group grants the
+kube-API proxy plus exposed Services. The chart provisions the group (Group
+CR) when the router or proxy is enabled; only the mesh DNS zone must
+pre-exist in NetBird (see printNetBirdOperatorInstructions).
+
+The router + traefik-internal resource render when a mesh DNS zone is set.
+ClusterProxy is named after cluster.name.
 */ -}}
 {{- if .NetBirdOperatorEnabled }}
 {{- if .NetBirdManagementURL }}
 netbird-operator:
   managementURL: {{ .NetBirdManagementURL | quote }}
+{{- end }}
+{{- if or .NetBirdRouterEnabled .NetBirdClusterProxyEnabled }}
+group: {{ .NetBirdClusterGroup | quote }}
 {{- end }}
 {{- if .NetBirdRouterEnabled }}
 networkRouter:
@@ -25,8 +34,6 @@ networkResources:
   - name: traefik-internal
     namespace: traefik
     service: traefik-internal
-    groups:
-      - {{ .NetBirdInternalIngressGroup | quote }}
 {{- end }}
 {{- if .NetBirdClusterProxyEnabled }}
 clusterProxy:

--- a/pkg/core/templates_netbird_operator_test.go
+++ b/pkg/core/templates_netbird_operator_test.go
@@ -47,29 +47,15 @@ func subMap(t *testing.T, m map[string]any, key string) map[string]any {
 	return sub
 }
 
-// stringSlice asserts v is a []any of strings (as produced by
-// sigs.k8s.io/yaml unmarshalling into map[string]any) and returns it as
-// a plain []string for comparison.
-func stringSlice(t *testing.T, v any) []string {
-	t.Helper()
-
-	raw, ok := v.([]any)
-	require.True(t, ok, "expected a slice, got %T", v)
-
-	out := make([]string, len(raw))
-	for i, e := range raw {
-		s, ok := e.(string)
-		require.True(t, ok, "expected element %d to be a string, got %T", i, e)
-		out[i] = s
-	}
-	return out
-}
-
 // TestNetBirdOperatorValuesTemplate covers values-netbird-operator.yaml.tmpl's
 // current shape: the whole overlay is gated on NetBirdOperatorEnabled, but
-// networkRouter / networkResources / clusterProxy render as TOP-LEVEL keys
-// (siblings of netbird-operator:, not nested under it) — only managementURL
-// nests under netbird-operator:, and only when it's non-empty.
+// group / networkRouter / networkResources / clusterProxy render as TOP-LEVEL
+// keys (siblings of netbird-operator:, not nested under it) — only
+// managementURL nests under netbird-operator:, and only when it's non-empty.
+//
+// group is the shared cluster group, emitted whenever the router or proxy is
+// enabled; the traefik-internal networkResource carries no groups of its own
+// so it inherits group, and the ClusterProxy joins it chart-side.
 //
 // Fixtures mirror getTemplateValues' invariants: NetBirdRouterEnabled=true
 // implies NetBird != nil (dnsZone comes from .NetBird.DNSZone), and
@@ -91,19 +77,23 @@ func TestNetBirdOperatorValuesTemplate(t *testing.T) {
 					},
 				},
 			},
-			NetBirdRouterEnabled:        true,
-			NetBirdClusterProxyEnabled:  true,
-			NetBirdInternalIngressGroup: "k8s-acme-prod",
+			NetBirdRouterEnabled:       true,
+			NetBirdClusterProxyEnabled: true,
+			NetBirdClusterGroup:        "k8s-acme-prod",
 		}
 
 		_, parsed := renderNetBirdOperatorValues(t, tv)
 
-		// networkRouter, networkResources, and clusterProxy are top-level
-		// siblings of netbird-operator — NOT nested under it.
-		require.Len(t, parsed, 4)
-		for _, key := range []string{"netbird-operator", "networkRouter", "networkResources", "clusterProxy"} {
+		// group, networkRouter, networkResources, and clusterProxy are
+		// top-level siblings of netbird-operator — NOT nested under it.
+		require.Len(t, parsed, 5)
+		for _, key := range []string{"netbird-operator", "group", "networkRouter", "networkResources", "clusterProxy"} {
 			assert.Contains(t, parsed, key)
 		}
+
+		// The shared cluster group both the ClusterProxy and the
+		// traefik-internal resource join.
+		assert.Equal(t, "k8s-acme-prod", parsed["group"])
 
 		op := subMap(t, parsed, "netbird-operator")
 		require.Len(t, op, 1, "netbird-operator only carries managementURL now")
@@ -122,7 +112,8 @@ func TestNetBirdOperatorValuesTemplate(t *testing.T) {
 		assert.Equal(t, "traefik-internal", res["name"])
 		assert.Equal(t, "traefik", res["namespace"])
 		assert.Equal(t, "traefik-internal", res["service"])
-		assert.Equal(t, []string{"k8s-acme-prod"}, stringSlice(t, res["groups"]))
+		_, hasGroups := res["groups"]
+		assert.False(t, hasGroups, "traefik-internal carries no groups of its own — it inherits the shared top-level group")
 
 		proxy := subMap(t, parsed, "clusterProxy")
 		assert.Equal(t, true, proxy["enabled"])
@@ -166,15 +157,16 @@ func TestNetBirdOperatorValuesTemplate(t *testing.T) {
 			NetBird: &config.NetBirdConfig{
 				DNSZone: "mesh.acme.com",
 			},
-			NetBirdRouterEnabled:        true,
-			NetBirdInternalIngressGroup: "k8s-acme-prod",
+			NetBirdRouterEnabled: true,
+			NetBirdClusterGroup:  "k8s-acme-prod",
 		}
 
 		_, parsed := renderNetBirdOperatorValues(t, tv)
 
-		require.Len(t, parsed, 2)
+		require.Len(t, parsed, 3)
 		assert.NotContains(t, parsed, "netbird-operator", "empty managementURL means no netbird-operator: key at all")
 		assert.NotContains(t, parsed, "clusterProxy")
+		assert.Equal(t, "k8s-acme-prod", parsed["group"])
 
 		router := subMap(t, parsed, "networkRouter")
 		assert.Equal(t, true, router["enabled"])
@@ -186,7 +178,8 @@ func TestNetBirdOperatorValuesTemplate(t *testing.T) {
 		require.Len(t, resourcesRaw, 1)
 		res, ok := resourcesRaw[0].(map[string]any)
 		require.True(t, ok)
-		assert.Equal(t, []string{"k8s-acme-prod"}, stringSlice(t, res["groups"]))
+		_, hasGroups := res["groups"]
+		assert.False(t, hasGroups, "traefik-internal inherits the shared top-level group, not its own")
 	})
 
 	t.Run("clusterProxy enabled alone: only top-level clusterProxy renders", func(t *testing.T) {
@@ -199,14 +192,16 @@ func TestNetBirdOperatorValuesTemplate(t *testing.T) {
 				},
 			},
 			NetBirdClusterProxyEnabled: true,
+			NetBirdClusterGroup:        "k8s-acme-prod",
 		}
 
 		_, parsed := renderNetBirdOperatorValues(t, tv)
 
-		require.Len(t, parsed, 1)
+		require.Len(t, parsed, 2)
 		assert.NotContains(t, parsed, "netbird-operator")
 		assert.NotContains(t, parsed, "networkRouter")
 		assert.NotContains(t, parsed, "networkResources")
+		assert.Equal(t, "k8s-acme-prod", parsed["group"], "the ClusterProxy joins the shared cluster group")
 
 		proxy := subMap(t, parsed, "clusterProxy")
 		assert.Equal(t, true, proxy["enabled"])


### PR DESCRIPTION
Matches `values-netbird-operator.yaml.tmpl` to kubeaid's shared top-level `group:` structure.

kubeaid promoted the netbird-operator group to a shared top-level `group:` (defaults to `clusterProxy.clusterName`, else `networkRouter.name`) that both the ClusterProxy peer and every `NetworkResource` without its own `groups` join. Our overlay never set it and pinned an explicit `groups: [k8s-<cluster>]` on the traefik-internal resource, so under the new chart the ClusterProxy defaulted into `<cluster.name>` while ingress stayed in `k8s-<cluster>` — two split groups, defeating the "one policy grants proxy + Services" design.

## Changes
- Emit the shared `group: k8s-<cluster>` whenever the router or proxy is enabled, and drop the redundant per-resource `groups` so `traefik-internal` inherits it.
- Rename `TemplateValues.NetBirdInternalIngressGroup` → `NetBirdClusterGroup` (it now drives the shared group, not just ingress).
- The chart now auto-provisions the group (`Group` CR), so drop the manual "create a group" dashboard step from `printNetBirdOperatorInstructions`; narrow the `docs/TODO.md` item to the mesh DNS zone.
- Update `templates_netbird_operator_test.go` to assert the top-level `group:` and that `traefik-internal` carries no groups of its own.

## Verification
`go build`, `go vet`, `golangci-lint` (0 issues), and `go test ./pkg/core/...` (incl. `pkg/core/netbird`) all pass.

Closes #17