### PR TITLE
netbird-operator: name the NetworkRouter after the cluster

### DIFF
--- a/pkg/core/templates/argocd-apps/values-netbird-operator.yaml.tmpl
+++ b/pkg/core/templates/argocd-apps/values-netbird-operator.yaml.tmpl
@@ -15,7 +15,9 @@ CR) when the router or proxy is enabled; only the mesh DNS zone must
 pre-exist in NetBird (see printNetBirdOperatorInstructions).
 
 The router + traefik-internal resource render when a mesh DNS zone is set.
-ClusterProxy is named after cluster.name.
+Both the NetworkRouter (networkRouter.name) and the ClusterProxy are named
+after cluster.name — unique per cluster so neither collides with another
+cluster's on a shared NetBird Management.
 */ -}}
 {{- if .NetBirdOperatorEnabled }}
 {{- if .NetBirdManagementURL }}
@@ -28,6 +30,7 @@ group: {{ .NetBirdClusterGroup | quote }}
 {{- if .NetBirdRouterEnabled }}
 networkRouter:
   enabled: true
+  name: {{ .ClusterConfig.Name | quote }}
   dnsZone: {{ .NetBird.DNSZone | quote }}
   replicas: 1
 networkResources:

--- a/pkg/core/templates_netbird_operator_test.go
+++ b/pkg/core/templates_netbird_operator_test.go
@@ -101,6 +101,7 @@ func TestNetBirdOperatorValuesTemplate(t *testing.T) {
 
 		router := subMap(t, parsed, "networkRouter")
 		assert.Equal(t, true, router["enabled"])
+		assert.Equal(t, "acme-prod", router["name"], "networkRouter.name tracks the cluster name")
 		assert.Equal(t, "mesh.acme.com", router["dnsZone"])
 		assert.EqualValues(t, 1, router["replicas"])
 
@@ -153,6 +154,7 @@ func TestNetBirdOperatorValuesTemplate(t *testing.T) {
 
 	t.Run("router enabled, no managementURL or clusterProxy: only top-level networkRouter/networkResources render", func(t *testing.T) {
 		tv := &TemplateValues{
+			ClusterConfig:          config.ClusterConfig{Name: "acme-prod"},
 			NetBirdOperatorEnabled: true,
 			NetBird: &config.NetBirdConfig{
 				DNSZone: "mesh.acme.com",
@@ -170,6 +172,7 @@ func TestNetBirdOperatorValuesTemplate(t *testing.T) {
 
 		router := subMap(t, parsed, "networkRouter")
 		assert.Equal(t, true, router["enabled"])
+		assert.Equal(t, "acme-prod", router["name"], "networkRouter.name tracks the cluster name")
 		assert.Equal(t, "mesh.acme.com", router["dnsZone"])
 		assert.EqualValues(t, 1, router["replicas"])
 


### PR DESCRIPTION
Follow-up to #18 (already merged): name the NetworkRouter after the cluster.

`networkRouter.name` was left unset, so the netbird-operator chart's default `cluster-router` applied. That name collides across clusters on a shared NetBird Management and diverges from `clusterProxy.clusterName`, which we already set to the cluster name.

Set `networkRouter.name` to `cluster.name` so the router peer is unique per cluster and consistent with the ClusterProxy. `networkResources[].networkRouterRef` and the shared-group default helper follow it automatically.

## Verification
`go build`, `go vet`, `golangci-lint` (0 issues), and `go test ./pkg/core/...` (incl. `pkg/core/netbird`) all pass. Both router test cases now assert `networkRouter.name == <cluster>`.