### PR TITLE
fix: compare ZFS disk types instead of device names in alikeness check

### DIFF
--- a/pkg/cloud/hetzner/storageplan.go
+++ b/pkg/cloud/hetzner/storageplan.go
@@ -59,8 +59,8 @@ func (h *Hetzner) GenerateStoragePlans(ctx context.Context, hetznerConfig *confi
 			host.WWNs = collectAndSortWWNs(sp.OS)
 		}
 
-		if !storageplan.AreStoragePlansAlike(storagePlans) {
-			return fmt.Errorf("control-plane storage plans aren't alike")
+		if err := storageplan.CheckStoragePlansAlike(storagePlans); err != nil {
+			return fmt.Errorf("control-plane storage plans aren't alike: %w", err)
 		}
 
 		allStoragePlans["control-plane"] = storagePlans
@@ -96,8 +96,8 @@ func (h *Hetzner) GenerateStoragePlans(ctx context.Context, hetznerConfig *confi
 			host.WWNs = collectAndSortWWNs(sp.OS)
 		}
 
-		if !storageplan.AreStoragePlansAlike(storagePlans) {
-			return fmt.Errorf("node-group %s storage plans aren't alike", nodeGroup.Name)
+		if err := storageplan.CheckStoragePlansAlike(storagePlans); err != nil {
+			return fmt.Errorf("node-group %s storage plans aren't alike: %w", nodeGroup.Name, err)
 		}
 
 		allStoragePlans[nodeGroup.Name] = storagePlans

--- a/pkg/storageplanner/storageplan/storageplans.go
+++ b/pkg/storageplanner/storageplan/storageplans.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"slices"
 	"sort"
 	"strings"
 	"unicode/utf8"
@@ -582,33 +583,45 @@ func (s *StoragePlans) GetApproval(ctx context.Context) {
 }
 
 /*
-By alikeness, I mean, the 2 disks across which the ZFS pool will be running, must be the same
-across all the nodes in the node-group. This makes the command to create a ZFS pool to be the same
-across the nodes, for e.g. :
+By alikeness, I mean, the disks across which the ZFS pool will be running, must be of the same
+count and type (SSD / HDD / NVMe) across all the nodes in the node-group.
 
-	zpool create primary mirror /dev/nvme0n1 /dev/nvme1n1
-
-For all the nodes in a node-group, we have a single KubeadmControlPlane / KubeadmConfig resource.
-And the ZFS pool creation command goes in the postKubeadm section of that resource. So, it must be
-same for all the nodes.
+All the nodes in a node-group share a single KubeadmControlPlane / KubeadmConfig resource, whose
+preKubeadm section runs the same `kubeaid-storagectl plan execute --os-size ... --zfs-pool-size ...`
+command on every node. Each node recomputes its own storage plan locally, so device names (sdc vs
+sdd) are free to differ between nodes — the kernel assigns them from port enumeration order, which
+isn't stable across otherwise identical machines. What must match is the resulting pool's shape:
+a mirror across 2 SSDs on one node and across 2 HDDs on another would give the node-group wildly
+different storage performance while being labelled identically.
 */
-func AreStoragePlansAlike(storagePlans []*StoragePlan) bool {
-	var referenceDisks []*Disk
-	for i, storagePlan := range storagePlans {
-		if i == 0 {
-			referenceDisks = storagePlan.ZFS
-			continue
-		}
+func CheckStoragePlansAlike(storagePlans []*StoragePlan) error {
+	if len(storagePlans) == 0 {
+		return nil
+	}
 
-		if len(storagePlan.ZFS) != len(referenceDisks) {
-			return false
-		}
-		for j, disk := range storagePlan.ZFS {
-			if referenceDisks[j].Name != disk.Name {
-				return false
-			}
+	reference := zfsDiskTypes(storagePlans[0])
+	for _, storagePlan := range storagePlans[1:] {
+		current := zfsDiskTypes(storagePlan)
+		if !slices.Equal(current, reference) {
+			return fmt.Errorf(
+				"server %s allocates the ZFS pool on %v, but server %s allocates it on %v",
+				storagePlan.ServerID, current,
+				storagePlans[0].ServerID, reference,
+			)
 		}
 	}
 
-	return true
+	return nil
+}
+
+// zfsDiskTypes returns the sorted disk types (SSD / HDD / NVMe) backing the
+// plan's ZFS pool. Sorted so CheckStoragePlansAlike compares them as a
+// multiset — allocation order within a plan carries no meaning.
+func zfsDiskTypes(storagePlan *StoragePlan) []string {
+	types := make([]string, 0, len(storagePlan.ZFS))
+	for _, disk := range storagePlan.ZFS {
+		types = append(types, disk.Type)
+	}
+	sort.Strings(types)
+	return types
 }

--- a/pkg/storageplanner/storageplan/storageplans_test.go
+++ b/pkg/storageplanner/storageplan/storageplans_test.go
@@ -14,84 +14,107 @@ import (
 	"github.com/Obmondo/kubeaid-cli/pkg/constants"
 )
 
-func TestAreStoragePlansAlike(t *testing.T) {
-	mkPlan := func(zfsDiskNames ...string) *StoragePlan {
-		disks := make([]*Disk, len(zfsDiskNames))
-		for i, name := range zfsDiskNames {
-			disks[i] = &Disk{Name: name}
+func TestCheckStoragePlansAlike(t *testing.T) {
+	mkPlan := func(serverID string, zfsDiskTypes ...string) *StoragePlan {
+		disks := make([]*Disk, len(zfsDiskTypes))
+		for i, diskType := range zfsDiskTypes {
+			disks[i] = &Disk{Type: diskType}
 		}
-		return &StoragePlan{ZFS: disks}
+		return &StoragePlan{ServerID: serverID, ZFS: disks}
 	}
 
 	tests := []struct {
-		name  string
-		plans []*StoragePlan
-		want  bool
+		name      string
+		plans     []*StoragePlan
+		wantAlike bool
 	}{
 		{
-			name:  "empty input",
-			plans: nil,
-			want:  true,
+			name:      "empty input",
+			plans:     nil,
+			wantAlike: true,
 		},
 		{
-			name:  "single plan",
-			plans: []*StoragePlan{mkPlan("nvme0n1", "nvme1n1")},
-			want:  true,
+			name:      "single plan",
+			plans:     []*StoragePlan{mkPlan("100", constants.DiskTypeNVMe, constants.DiskTypeNVMe)},
+			wantAlike: true,
 		},
 		{
-			name: "all plans share the same ZFS disks",
+			name: "all plans share the same ZFS disk types",
 			plans: []*StoragePlan{
-				mkPlan("nvme0n1", "nvme1n1"),
-				mkPlan("nvme0n1", "nvme1n1"),
-				mkPlan("nvme0n1", "nvme1n1"),
+				mkPlan("100", constants.DiskTypeNVMe, constants.DiskTypeNVMe),
+				mkPlan("101", constants.DiskTypeNVMe, constants.DiskTypeNVMe),
+				mkPlan("102", constants.DiskTypeNVMe, constants.DiskTypeNVMe),
 			},
-			want: true,
+			wantAlike: true,
 		},
 		{
-			name: "first disk diverges",
+			// The SATA-port-ordering case: the same 2 SSDs enumerate at
+			// different device names on each node. Names carry no meaning —
+			// every node runs `kubeaid-storagectl plan execute` and picks
+			// its own devices — so these plans are alike.
+			name: "same disk types at different device names are alike",
 			plans: []*StoragePlan{
-				mkPlan("nvme0n1", "nvme1n1"),
-				mkPlan("sda", "sdb"),
+				{ServerID: "100", ZFS: []*Disk{
+					{Name: "sdb", Type: constants.DiskTypeSSD},
+					{Name: "sdd", Type: constants.DiskTypeSSD},
+				}},
+				{ServerID: "101", ZFS: []*Disk{
+					{Name: "sdb", Type: constants.DiskTypeSSD},
+					{Name: "sdc", Type: constants.DiskTypeSSD},
+				}},
 			},
-			want: false,
+			wantAlike: true,
 		},
 		{
-			name: "second disk diverges",
+			name: "disk type diverges",
 			plans: []*StoragePlan{
-				mkPlan("sda", "sdb"),
-				mkPlan("sda", "sdc"),
+				mkPlan("100", constants.DiskTypeSSD, constants.DiskTypeSSD),
+				mkPlan("101", constants.DiskTypeHDD, constants.DiskTypeHDD),
 			},
-			want: false,
+			wantAlike: false,
+		},
+		{
+			name: "mixed-type pool diverges from uniform pool",
+			plans: []*StoragePlan{
+				mkPlan("100", constants.DiskTypeSSD, constants.DiskTypeSSD),
+				mkPlan("101", constants.DiskTypeSSD, constants.DiskTypeHDD),
+			},
+			wantAlike: false,
 		},
 		{
 			name: "later plan has more ZFS disks than the first",
 			plans: []*StoragePlan{
-				mkPlan("nvme0n1"),
-				mkPlan("nvme0n1", "nvme1n1"),
+				mkPlan("100", constants.DiskTypeNVMe),
+				mkPlan("101", constants.DiskTypeNVMe, constants.DiskTypeNVMe),
 			},
-			want: false,
+			wantAlike: false,
 		},
 		{
 			name: "later plan has fewer ZFS disks than the first",
 			plans: []*StoragePlan{
-				mkPlan("nvme0n1", "nvme1n1"),
-				mkPlan("nvme0n1"),
+				mkPlan("100", constants.DiskTypeNVMe, constants.DiskTypeNVMe),
+				mkPlan("101", constants.DiskTypeNVMe),
 			},
-			want: false,
+			wantAlike: false,
 		},
 		{
 			name: "all plans have no ZFS disks",
 			plans: []*StoragePlan{
-				mkPlan(),
-				mkPlan(),
+				mkPlan("100"),
+				mkPlan("101"),
 			},
-			want: true,
+			wantAlike: true,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, AreStoragePlansAlike(tc.plans))
+			err := CheckStoragePlansAlike(tc.plans)
+			if tc.wantAlike {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
The storage-plan alikeness check rejected node-groups whose ZFS disks sat at different device names (sdb+sdd vs sdb+sdc), even when the disks were functionally identical. Device names come from kernel port enumeration and aren't stable across otherwise-alike machines.

The name comparison guarded a design that no longer exists: the shared KubeadmControlPlane/KubeadmConfig script contains no device names — each node runs `kubeaid-storagectl plan execute` and picks its own disks. What must actually match is the pool's shape, so compare ZFS disk count + type (SSD/HDD/NVMe) instead. The error now names the diverging server and both disk-type lists.