### PR TITLE
fix(cog): push releases to the gitea remote, not the nonexistent github one

### DIFF
--- a/cog.toml
+++ b/cog.toml
@@ -19,8 +19,9 @@ pre_bump_hooks = [
 ]
 
 post_bump_hooks = [
+  # origin is the GitHub repo.
   "git push origin main {{version_tag}}",
-  "git push github main {{version_tag}}",
+  "git push gitea main {{version_tag}}",
 ]
 
 ignore_merge_commits = true


### PR DESCRIPTION
cog's second post-bump hook pushed to a remote named `github`, which doesn't exist in this repo — `origin` already points at GitHub and the Gitea copy is the remote named `gitea`. Every `cog bump` therefore exited 128 on the last hook after the origin push had already succeeded (v0.30.0 landed on GitHub but never reached Gitea).

Point the hook at `gitea` so the next bump syncs both remotes.
