### PR TITLE
feat: add backup status

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ From there it is **GitOps**. The engine renders your `general.yaml` into manifes
 ## Features
 
 - **Cluster lifecycle management** — bootstrap, upgrade, recover, test, and delete Kubernetes clusters
+- **Backup status reporting** — `backup status` shows CNPG and Velero backup health at a glance, see [`docs/backup-status.md`](docs/backup-status.md)
 - **Development environments** — spin up local K3D-based dev clusters
 - **Multi-cloud support** — AWS, Azure, Hetzner (cloud, bare-metal, hybrid), and generic bare-metal
 - **GitOps native** — integrates with ArgoCD, KubeAid Config repos, and sealed secrets
@@ -166,6 +167,7 @@ See [`docs/config-reference.md`](docs/config-reference.md) for the full configur
 **Day-to-day operator guides**
 
 - [Post-bootstrap checklist](docs/post-bootstrap.md) — what to do right after a cluster comes up
+- [Backup status](docs/backup-status.md) — check CNPG and Velero backup health via backup-exporter
 - [Add a bare-metal worker](docs/add-bare-metal-worker.md) — grow a Hetzner bare-metal worker pool (see also the [manual git-only flow](docs/add-bare-metal-worker-manual.md))
 - [Upgrade a bare-metal cluster](docs/upgrade-bare-metal.md) — bump the Kubernetes version of a bare-metal (KubeOne) cluster
 - [Troubleshooting](docs/troubleshooting.md) — recovery paths for recurring bootstrap failures (Hetzner, Sealed Secrets, ArgoCD)

--- a/cmd/kubeaid-core/root/backup/backup.go
+++ b/cmd/kubeaid-core/root/backup/backup.go
@@ -1,0 +1,19 @@
+// Copyright 2026 Obmondo
+// SPDX-License-Identifier: AGPL3
+
+package backup
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// BackupCmd only groups backup subcommands; unlike the cluster group it has no
+// PersistentPreRun, so subcommands run without any parsed cluster config.
+var BackupCmd = &cobra.Command{
+	Use:   "backup",
+	Short: "Inspect backups of a KubeAid managed K8s cluster",
+}
+
+func init() {
+	BackupCmd.AddCommand(StatusCmd)
+}

--- a/cmd/kubeaid-core/root/backup/status.go
+++ b/cmd/kubeaid-core/root/backup/status.go
@@ -1,0 +1,43 @@
+// Copyright 2026 Obmondo
+// SPDX-License-Identifier: AGPL3
+
+package backup
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obmondo/kubeaid-cli/pkg/constants"
+	"github.com/Obmondo/kubeaid-cli/pkg/core"
+	"github.com/Obmondo/kubeaid-cli/pkg/utils/assert"
+)
+
+var StatusCmd = &cobra.Command{
+	Use: "status",
+
+	Short: "Show backup health of the cluster (CNPG and Velero), as reported by backup-exporter",
+
+	Args: cobra.NoArgs,
+
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := cmd.Context()
+
+		assert.Assert(ctx,
+			outputFormat == "" || outputFormat == "json",
+			fmt.Sprintf("invalid --%s value %q: only \"json\" is supported",
+				constants.FlagNameOutput, outputFormat),
+		)
+
+		core.BackupStatus(ctx, outputFormat)
+	},
+}
+
+var outputFormat string
+
+func init() {
+	StatusCmd.Flags().
+		StringVarP(&outputFormat, constants.FlagNameOutput, "o", "",
+			`Output format. Only "json" is supported; omit for human-readable output`,
+		)
+}

--- a/cmd/kubeaid-core/root/root.go
+++ b/cmd/kubeaid-core/root/root.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/Obmondo/kubeaid-cli/cmd/kubeaid-core/root/backup"
 	"github.com/Obmondo/kubeaid-cli/cmd/kubeaid-core/root/cluster"
 	"github.com/Obmondo/kubeaid-cli/cmd/kubeaid-core/root/config"
 	"github.com/Obmondo/kubeaid-cli/cmd/kubeaid-core/root/devenv"
@@ -63,6 +64,7 @@ func init() {
 	// Subcommands.
 	RootCmd.AddCommand(config.ConfigCmd)
 	RootCmd.AddCommand(devenv.DevenvCmd)
+	RootCmd.AddCommand(backup.BackupCmd)
 	RootCmd.AddCommand(cluster.ClusterCmd)
 	RootCmd.AddCommand(version.VersionCommand)
 

--- a/docs/backup-status.md
+++ b/docs/backup-status.md
@@ -1,0 +1,152 @@
+# `backup status`
+
+## Overview
+
+`kubeaid-cli backup status` reports the backup health of a KubeAid managed cluster —
+CNPG (PostgreSQL) and Velero (volume/PVC) backups — as observed by the in-cluster
+[backup-exporter](https://github.com/Obmondo/backup-exporter). It's a read-only report:
+nothing is modified on the cluster or in Git.
+
+## Purpose
+
+Backup health lives in Prometheus metrics scraped from backup-exporter, which is fine for
+alerting but awkward to check by hand — an operator has to know the metric names and
+reconcile a handful of gauges into "is this resource actually backed up." backup-exporter's
+`GET /api/v1/backups` endpoint already does that reconciliation server-side and returns one
+evaluated status per resource. `backup status` is a thin client for that endpoint:
+fetch, adjust the ages for time elapsed since collection, and print.
+
+## Behavior
+
+1. Builds a Kubernetes client from the current kubeconfig — the same one `kubectl` would use
+   (`$KUBECONFIG`, else `~/.kube/config`, current context).
+2. Finds backup-exporter's Service by label (`app.kubernetes.io/name=backup-exporter`) across
+   all namespaces. Zero or more than one match is a hard error naming the namespace(s)
+   involved.
+3. Resolves a target pod behind that Service: lists pods matching the Service's own
+   `.spec.selector` and picks the first one that's `Running` with a `Ready=True` condition.
+   Then resolves the Service's port (named `http`, or its only port either way) to a container
+   port on that pod — numeric `targetPort` used directly, a named one looked up by container
+   port name.
+4. Fetches `GET /api/v1/backups` the same way `kubectl port-forward` does: opens the
+   `pods/portforward` subresource (an upgraded SPDY/WebSocket stream, not a plain HTTP proxy
+   hop), forwards an ephemeral local port to the pod's resolved target port, issues the GET
+   against `127.0.0.1`, then tears the tunnel down. No `kubectl` binary is required — this
+   dials the same subresource client-go itself, not a spawned child process.
+5. Renders the response:
+   - `-o json` prints the response body verbatim, byte for byte, as returned by the server.
+   - Otherwise, prints a human-readable report (see below).
+
+Exit code is non-zero only when the fetch or decode itself fails (bad kubeconfig, Service or
+pod not found, network error, malformed JSON). A cluster full of `exceeds_rpo` or `no_backup`
+resources still exits `0` — this is a report, not a health gate; wire it into alerting
+separately if you want it to fail a pipeline.
+
+### Why port-forward, not the Service proxy subresource
+
+An earlier version of this command fetched through the API server's `services/proxy`
+subresource (`GET .../services/http:backup-exporter:8080/proxy/...`) — the same path
+`kubectl proxy` uses. That breaks for clusters reached through an L7 proxy in front of
+kube-apiserver, such as KubeAid's netbird `ClusterProxy`: it returns `404` for
+`services/.../proxy/...` requests specifically, even though the apiserver itself is otherwise
+fully reachable through it. `pods/portforward` upgrades to a raw SPDY/WebSocket stream instead
+of an HTTP proxy hop, which is the mechanism such proxies are built to pass through — it's how
+plain `kubectl port-forward` already works everywhere these clusters are accessed from.
+
+### Human-readable report
+
+```
+collected 87m ago: cnpg | velero
+
+Operator errors:
+  cnpg: s3_list_failed
+
+NAMESPACE    RESOURCE       TYPE           STREAM    METHOD        LATEST AGE   STATUS
+demo         demo-pgsql     cnpg_cluster   logical   -             none         no_backup
+demo         demo-pgsql     cnpg_cluster   wal       -             159m         healthy
+demo         demo-uploads   pvc            volume    kopia         13h          healthy
+monitoring   obs-postgres   cnpg_cluster   logical   -             none         no_backup
+monitoring   prom-data      pvc            volume    CSISnapshot   13h          healthy
+3 healthy, 2 no_backup
+```
+
+- One freshness line for all operators, condensing to `collected 87m ago: cnpg | velero` when
+  they agree. Operators whose collections disagree are listed individually
+  (`collected: velero 5m ago | cnpg never`); one that has never completed a run reads `never`
+  rather than being omitted.
+- Operator errors — collector failures with no single resource to attach to, e.g. Velero
+  failing to list its S3 bucket — print prominently, before the table.
+- The table is plain aligned columns, the same shape `kubectl get` prints: no borders, no
+  colour, one row per backup stream per resource, sorted by namespace then resource name. A
+  CNPG cluster contributes one row per stream (`logical`, `wal`). The `METHOD` column (Velero's
+  `PodVolumeBackup` / `CSISnapshot` / `kopia`) only appears when at least one row has one.
+- Staying line-oriented keeps the report greppable: `backup status | grep -v healthy` leaves
+  every failing row complete, namespace included.
+- `LATEST AGE` is humanized and adjusted for time elapsed since that operator's last
+  collection — backup-exporter measures ages at collection time, not request time, so a stale
+  collector under-reports without this adjustment. `-` means no series was published for that
+  age (nothing to measure yet); `none` means a series was published reporting exactly zero —
+  the operators' shared "no backup exists" sentinel.
+- `STATUS` is one of `healthy`, `exceeds_rpo`, `no_backup`, `collector_error`, `unknown`; a
+  `collector_error` row also shows the failure reason in parentheses.
+- The summary line always counts every resource, ordered healthy first.
+
+## Configuration
+
+Nothing feature-specific. The Service is discovered dynamically by label — there is no
+`general.yaml` field for a namespace or Service name, and no CLI flag duplicates that
+discovery. The only flag is `-o`/`--output`, which accepts `json` or is omitted.
+
+Unlike the `cluster` subcommands, the `backup` group has no config-parsing
+`PersistentPreRun`: no `general.yaml`/`secrets.yaml` is read at all. The command connects
+with your current kubeconfig, exactly like kubectl (`$KUBECONFIG`, else `~/.kube/config`,
+current context) -- if `kubectl get svc -n monitoring` works, so does this. It deliberately
+avoids the KubeOne-generated `outputs/` kubeconfig, whose endpoint is only reachable through
+the provisioning SSH tunnel.
+
+### RBAC
+
+The identity in your kubeconfig needs, cluster-wide (backup-exporter's namespace isn't known
+ahead of time, since it's discovered by label):
+
+- `list` on `services` and `pods`
+- `create` on `pods/portforward`
+
+This is a strict superset of what the old `services/proxy` path needed, and matches exactly
+what `kubectl port-forward` itself requires — if your identity can already
+`kubectl port-forward` a pod, it can run this command.
+
+## Edge cases
+
+| Situation | Behavior |
+|---|---|
+| backup-exporter not installed | Fetch fails fast: "no backup-exporter service found ... is the backup-exporter chart installed?" |
+| Two backup-exporter Services (e.g. mid-migration) | Fetch fails, naming every namespace found, rather than guessing which one to use. |
+| No pod behind the Service is `Running` + `Ready` (e.g. mid-rollout, or `CrashLoopBackOff`) | Fetch fails: "no ready pod behind service `<namespace>/<name>`". |
+| Service has more than one port and none is named `http` | Fetch fails naming the Service and its port count, rather than guessing which port to forward. |
+| A named `targetPort` isn't declared on the pod's containers | Fetch fails naming the pod and the missing port name. |
+| The port-forward tunnel never becomes ready within 15s (e.g. an L7 proxy silently drops the upgrade) | Fetch fails with a timeout error naming the pod. |
+| An operator has never completed a collection | Its freshness line reads "no completed collection run yet" instead of silently showing an empty table section. |
+| A resource's age field is `null` | Rendered as `-`, distinct from `none` (an actual reported zero). |
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+    actor Operator
+    participant CLI as kubeaid-cli
+    participant API as Kubernetes API server
+    participant BE as backup-exporter pod (in-cluster)
+
+    Operator->>CLI: kubeaid-cli backup status
+    CLI->>API: List Services (label app.kubernetes.io/name=backup-exporter)
+    API-->>CLI: Service namespace/name
+    CLI->>API: Get Service, List pods (Service's own .spec.selector)
+    API-->>CLI: Service ports + first Running/Ready pod
+    CLI->>API: POST pods/<pod>/portforward (upgrade to SPDY/WebSocket)
+    API-->>CLI: upgraded stream, ephemeral local port ready
+    CLI->>BE: GET 127.0.0.1:<local port>/api/v1/backups (tunneled)
+    BE-->>CLI: JSON backup status
+    CLI->>API: close portforward stream
+    CLI-->>Operator: human-readable report (or raw JSON with -o json)
+```

--- a/docs/backup-status.md
+++ b/docs/backup-status.md
@@ -1,152 +1,65 @@
 # `backup status`
 
-## Overview
+Reports CNPG (PostgreSQL) and Velero (volume/PVC) backup health, as evaluated by the in-cluster
+[backup-exporter](https://github.com/Obmondo/backup-exporter). Read-only: it changes nothing on
+the cluster or in Git.
 
-`kubeaid-cli backup status` reports the backup health of a KubeAid managed cluster —
-CNPG (PostgreSQL) and Velero (volume/PVC) backups — as observed by the in-cluster
-[backup-exporter](https://github.com/Obmondo/backup-exporter). It's a read-only report:
-nothing is modified on the cluster or in Git.
-
-## Purpose
-
-Backup health lives in Prometheus metrics scraped from backup-exporter, which is fine for
-alerting but awkward to check by hand — an operator has to know the metric names and
-reconcile a handful of gauges into "is this resource actually backed up." backup-exporter's
-`GET /api/v1/backups` endpoint already does that reconciliation server-side and returns one
-evaluated status per resource. `backup status` is a thin client for that endpoint:
-fetch, adjust the ages for time elapsed since collection, and print.
-
-## Behavior
-
-1. Builds a Kubernetes client from the current kubeconfig — the same one `kubectl` would use
-   (`$KUBECONFIG`, else `~/.kube/config`, current context).
-2. Finds backup-exporter's Service by label (`app.kubernetes.io/name=backup-exporter`) across
-   all namespaces. Zero or more than one match is a hard error naming the namespace(s)
-   involved.
-3. Resolves a target pod behind that Service: lists pods matching the Service's own
-   `.spec.selector` and picks the first one that's `Running` with a `Ready=True` condition.
-   Then resolves the Service's port (named `http`, or its only port either way) to a container
-   port on that pod — numeric `targetPort` used directly, a named one looked up by container
-   port name.
-4. Fetches `GET /api/v1/backups` the same way `kubectl port-forward` does: opens the
-   `pods/portforward` subresource (an upgraded SPDY/WebSocket stream, not a plain HTTP proxy
-   hop), forwards an ephemeral local port to the pod's resolved target port, issues the GET
-   against `127.0.0.1`, then tears the tunnel down. No `kubectl` binary is required — this
-   dials the same subresource client-go itself, not a spawned child process.
-5. Renders the response:
-   - `-o json` prints the response body verbatim, byte for byte, as returned by the server.
-   - Otherwise, prints a human-readable report (see below).
-
-Exit code is non-zero only when the fetch or decode itself fails (bad kubeconfig, Service or
-pod not found, network error, malformed JSON). A cluster full of `exceeds_rpo` or `no_backup`
-resources still exits `0` — this is a report, not a health gate; wire it into alerting
-separately if you want it to fail a pipeline.
-
-### Why port-forward, not the Service proxy subresource
-
-An earlier version of this command fetched through the API server's `services/proxy`
-subresource (`GET .../services/http:backup-exporter:8080/proxy/...`) — the same path
-`kubectl proxy` uses. That breaks for clusters reached through an L7 proxy in front of
-kube-apiserver, such as KubeAid's netbird `ClusterProxy`: it returns `404` for
-`services/.../proxy/...` requests specifically, even though the apiserver itself is otherwise
-fully reachable through it. `pods/portforward` upgrades to a raw SPDY/WebSocket stream instead
-of an HTTP proxy hop, which is the mechanism such proxies are built to pass through — it's how
-plain `kubectl port-forward` already works everywhere these clusters are accessed from.
-
-### Human-readable report
+## Usage
 
 ```
-collected 87m ago: cnpg | velero
+kubeaid-cli backup status          # human-readable report
+kubeaid-cli backup status -o json  # the exporter's response, verbatim
+```
+
+- Uses your current kubeconfig, like kubectl. If `kubectl get svc -n monitoring` works, so does
+  this.
+- Finds the exporter itself — `monitoring` first, then every namespace. Nothing to configure, no
+  `general.yaml` involved.
+- Reaches it by port-forward, exactly as `kubectl port-forward` would, so it works through
+  netbird's `ClusterProxy`. Your identity needs what `kubectl port-forward` needs in the
+  exporter's namespace.
+- Always exits `0` when it can report, however unhealthy the backups are. Non-zero means it
+  could not fetch.
+
+## Output
+
+```
+collected 2h 57m ago: cnpg | velero
 
 Operator errors:
   cnpg: s3_list_failed
 
-NAMESPACE    RESOURCE       TYPE           STREAM    METHOD        LATEST AGE   STATUS
-demo         demo-pgsql     cnpg_cluster   logical   -             none         no_backup
-demo         demo-pgsql     cnpg_cluster   wal       -             159m         healthy
-demo         demo-uploads   pvc            volume    kopia         13h          healthy
-monitoring   obs-postgres   cnpg_cluster   logical   -             none         no_backup
-monitoring   prom-data      pvc            volume    CSISnapshot   13h          healthy
-3 healthy, 2 no_backup
+NAMESPACE    RESOURCE       TYPE           STREAM    METHOD            LATEST AGE   STATUS
+demo         demo-pgsql     cnpg_cluster   logical   CronJob           none         collector_error (cronjob_not_found)
+demo         demo-pgsql     cnpg_cluster   wal       Barman            4h 9m        healthy
+demo         demo-uploads   pvc            volume    PodVolumeBackup   14h 57m      healthy
+monitoring   obs-postgres   cnpg_cluster   logical   cronjob           3d 2h        exceeds_rpo
+monitoring   prom-data      pvc            volume    CSISnapshot       14h 57m      healthy
+4 resources: 2 healthy, 1 exceeds_rpo, 1 collector_error
 ```
 
-- One freshness line for all operators, condensing to `collected 87m ago: cnpg | velero` when
-  they agree. Operators whose collections disagree are listed individually
-  (`collected: velero 5m ago | cnpg never`); one that has never completed a run reads `never`
-  rather than being omitted.
-- Operator errors — collector failures with no single resource to attach to, e.g. Velero
-  failing to list its S3 bucket — print prominently, before the table.
-- The table is plain aligned columns, the same shape `kubectl get` prints: no borders, no
-  colour, one row per backup stream per resource, sorted by namespace then resource name. A
-  CNPG cluster contributes one row per stream (`logical`, `wal`). The `METHOD` column (Velero's
-  `PodVolumeBackup` / `CSISnapshot` / `kopia`) only appears when at least one row has one.
-- Staying line-oriented keeps the report greppable: `backup status | grep -v healthy` leaves
-  every failing row complete, namespace included.
-- `LATEST AGE` is humanized and adjusted for time elapsed since that operator's last
-  collection — backup-exporter measures ages at collection time, not request time, so a stale
-  collector under-reports without this adjustment. `-` means no series was published for that
-  age (nothing to measure yet); `none` means a series was published reporting exactly zero —
-  the operators' shared "no backup exists" sentinel.
-- `STATUS` is one of `healthy`, `exceeds_rpo`, `no_backup`, `collector_error`, `unknown`; a
-  `collector_error` row also shows the failure reason in parentheses.
-- The summary line always counts every resource, ordered healthy first.
+- **Freshness line** — how long ago the exporter last looked. One age when the collectors agree,
+  per-collector when they don't (`collected: velero 5m ago | cnpg never`).
+- **Operator errors** — failures with no single resource to blame, e.g. Velero cannot list its
+  bucket. Everything below them is that much less trustworthy.
+- **Rows** — one per backup stream, sorted by namespace then resource. A CNPG cluster gives a
+  `logical` and a `wal` row.
+- **`STREAM` / `METHOD`** — what is backed up, and what takes it. `METHOD` names the thing to go
+  look at when a row fails: `CronJob` for CNPG's logical dump, `Barman` for its WAL archive (the
+  barman-cloud plugin in the Cluster CR), and Velero's own `PodVolumeBackup` / `CSISnapshot`.
+- **`LATEST AGE`** — age of the newest backup (`2h 57m`, `3d 2h`), `none` when there is none at
+  all, `-` when the exporter published nothing to measure.
+- **`STATUS`** — `healthy`, `exceeds_rpo`, `no_backup`, `collector_error` (reason in
+  parentheses) or `unknown`.
+- **Summary** — counts resources, not rows. A resource whose streams disagree is counted once,
+  under its worst one, so the figures never add up to more than you have.
+- Every row carries its namespace, so `backup status | grep -v healthy` gives you complete lines.
 
-## Configuration
+## When it cannot report
 
-Nothing feature-specific. The Service is discovered dynamically by label — there is no
-`general.yaml` field for a namespace or Service name, and no CLI flag duplicates that
-discovery. The only flag is `-o`/`--output`, which accepts `json` or is omitted.
-
-Unlike the `cluster` subcommands, the `backup` group has no config-parsing
-`PersistentPreRun`: no `general.yaml`/`secrets.yaml` is read at all. The command connects
-with your current kubeconfig, exactly like kubectl (`$KUBECONFIG`, else `~/.kube/config`,
-current context) -- if `kubectl get svc -n monitoring` works, so does this. It deliberately
-avoids the KubeOne-generated `outputs/` kubeconfig, whose endpoint is only reachable through
-the provisioning SSH tunnel.
-
-### RBAC
-
-The identity in your kubeconfig needs, cluster-wide (backup-exporter's namespace isn't known
-ahead of time, since it's discovered by label):
-
-- `list` on `services` and `pods`
-- `create` on `pods/portforward`
-
-This is a strict superset of what the old `services/proxy` path needed, and matches exactly
-what `kubectl port-forward` itself requires — if your identity can already
-`kubectl port-forward` a pod, it can run this command.
-
-## Edge cases
-
-| Situation | Behavior |
+| Situation | What you see |
 |---|---|
-| backup-exporter not installed | Fetch fails fast: "no backup-exporter service found ... is the backup-exporter chart installed?" |
-| Two backup-exporter Services (e.g. mid-migration) | Fetch fails, naming every namespace found, rather than guessing which one to use. |
-| No pod behind the Service is `Running` + `Ready` (e.g. mid-rollout, or `CrashLoopBackOff`) | Fetch fails: "no ready pod behind service `<namespace>/<name>`". |
-| Service has more than one port and none is named `http` | Fetch fails naming the Service and its port count, rather than guessing which port to forward. |
-| A named `targetPort` isn't declared on the pod's containers | Fetch fails naming the pod and the missing port name. |
-| The port-forward tunnel never becomes ready within 15s (e.g. an L7 proxy silently drops the upgrade) | Fetch fails with a timeout error naming the pod. |
-| An operator has never completed a collection | Its freshness line reads "no completed collection run yet" instead of silently showing an empty table section. |
-| A resource's age field is `null` | Rendered as `-`, distinct from `none` (an actual reported zero). |
-
-## Diagram
-
-```mermaid
-sequenceDiagram
-    actor Operator
-    participant CLI as kubeaid-cli
-    participant API as Kubernetes API server
-    participant BE as backup-exporter pod (in-cluster)
-
-    Operator->>CLI: kubeaid-cli backup status
-    CLI->>API: List Services (label app.kubernetes.io/name=backup-exporter)
-    API-->>CLI: Service namespace/name
-    CLI->>API: Get Service, List pods (Service's own .spec.selector)
-    API-->>CLI: Service ports + first Running/Ready pod
-    CLI->>API: POST pods/<pod>/portforward (upgrade to SPDY/WebSocket)
-    API-->>CLI: upgraded stream, ephemeral local port ready
-    CLI->>BE: GET 127.0.0.1:<local port>/api/v1/backups (tunneled)
-    BE-->>CLI: JSON backup status
-    CLI->>API: close portforward stream
-    CLI-->>Operator: human-readable report (or raw JSON with -o json)
-```
+| backup-exporter not installed | "no backup-exporter service found ... is the backup-exporter chart installed?" |
+| Its pod is not `Running` + `Ready` | "no ready pod behind service `<namespace>/<name>`" |
+| Two exporters, neither in `monitoring` | Every `namespace/name` found, rather than a guess at which to use |
+| The connection never comes up | A timeout after 15s, naming the pod |

--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	k8s.io/client-go v0.35.1
 	k8s.io/cloud-provider v0.35.0
 	k8s.io/klog/v2 v2.130.1
+	k8s.io/kubectl v0.35.1
 	k8s.io/kubernetes v1.33.11
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 	sigs.k8s.io/cluster-api v1.11.10
@@ -470,7 +471,6 @@ require (
 	k8s.io/kube-aggregator v0.35.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
 	k8s.io/kube-proxy v0.35.0 // indirect
-	k8s.io/kubectl v0.35.1 // indirect
 	k8s.io/kubelet v0.35.0 // indirect
 	kubevirt.io/api v1.3.1 // indirect
 	kubevirt.io/containerized-data-importer-api v1.60.3 // indirect

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -32,6 +32,8 @@ const (
 const (
 	FlagNameDebug = "debug"
 
+	FlagNameOutput = "output"
+
 	FlagNameKubeAidVersion = "kubeaid-version"
 
 	FlagNameManagementClusterName = "management-cluster-name"

--- a/pkg/core/backup_status.go
+++ b/pkg/core/backup_status.go
@@ -19,7 +19,6 @@ import (
 	coreV1 "k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/util/duration"
 	"k8s.io/apimachinery/pkg/util/httpstream"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	k8sclientset "k8s.io/client-go/kubernetes"
@@ -63,6 +62,10 @@ const (
 	backupExporterServicePortName = "http"
 	backupExporterAPIPath         = "/api/v1/backups"
 )
+
+// backupExporterDefaultNamespace is where the KubeAid chart installs backup-exporter, and so
+// where its Service is looked for first.
+const backupExporterDefaultNamespace = "monitoring"
 
 // portForwardReadyTimeout bounds how long fetchViaPortForward waits for the tunnel to come up
 // before giving up - a dial that never resolves (e.g. a proxy silently dropping the upgrade)
@@ -145,13 +148,50 @@ func BackupStatus(ctx context.Context, outputFormat string) {
 	fmt.Print(renderBackupStatus(response, time.Now())) //nolint:forbidigo // operator-facing terminal output
 }
 
-// findBackupExporterService locates backup-exporter's Service by label across every
-// namespace. Errors when none or more than one match, naming the namespaces found so the
-// operator knows what to look at. Returns the full Service (not just its namespace/name) so
-// callers needing .Spec.Selector or .Spec.Ports - port-forwarding does - don't need a second
-// List/Get round trip, and RBAC stays to `list` on services rather than also needing `get`.
+// findBackupExporterService locates backup-exporter's Service by label, looking in
+// backupExporterDefaultNamespace first and falling back to every namespace when that comes up
+// empty or is refused - so a chart installed elsewhere is still found, while the common case
+// needs no cluster-wide list permission. The fallback errors when none or more than one match,
+// naming what it found. Returns the full Service (not just its namespace/name) so callers
+// needing .Spec.Selector or .Spec.Ports - port-forwarding does - don't need a second List/Get
+// round trip, and RBAC stays to `list` on services rather than also needing `get`.
 func findBackupExporterService(ctx context.Context, clientset k8sclientset.Interface) (*coreV1.Service, error) {
-	services, err := clientset.CoreV1().Services(metaV1.NamespaceAll).List(ctx, metaV1.ListOptions{
+	if services, err := listBackupExporterServices(ctx, clientset, backupExporterDefaultNamespace); err == nil && len(services) == 1 {
+		return &services[0], nil
+	}
+
+	services, err := listBackupExporterServices(ctx, clientset, metaV1.NamespaceAll)
+	if err != nil {
+		return nil, err
+	}
+
+	switch len(services) {
+	case 0:
+		return nil, fmt.Errorf(
+			"no backup-exporter service found (label %s=%s) in any namespace; is the backup-exporter chart installed?",
+			backupExporterLabelKey, backupExporterLabelValue)
+
+	case 1:
+		return &services[0], nil
+
+	default:
+		found := make([]string, 0, len(services))
+		for _, svc := range services {
+			found = append(found, svc.Namespace+"/"+svc.Name)
+		}
+		sort.Strings(found)
+
+		return nil, fmt.Errorf(
+			"found %d backup-exporter services (label %s=%s) and none in %s, expected exactly 1: %s",
+			len(services), backupExporterLabelKey, backupExporterLabelValue,
+			backupExporterDefaultNamespace, strings.Join(found, ", "))
+	}
+}
+
+// listBackupExporterServices lists the Services carrying backup-exporter's chart label in one
+// namespace, or in every namespace when namespace is metaV1.NamespaceAll.
+func listBackupExporterServices(ctx context.Context, clientset k8sclientset.Interface, namespace string) ([]coreV1.Service, error) {
+	services, err := clientset.CoreV1().Services(namespace).List(ctx, metaV1.ListOptions{
 		LabelSelector: backupExporterLabelKey + "=" + backupExporterLabelValue,
 	})
 	if err != nil {
@@ -159,26 +199,7 @@ func findBackupExporterService(ctx context.Context, clientset k8sclientset.Inter
 			backupExporterLabelKey, backupExporterLabelValue, err)
 	}
 
-	switch len(services.Items) {
-	case 0:
-		return nil, fmt.Errorf(
-			"no backup-exporter service found (label %s=%s) in any namespace; is the backup-exporter chart installed?",
-			backupExporterLabelKey, backupExporterLabelValue)
-
-	case 1:
-		svc := services.Items[0]
-		return &svc, nil
-
-	default:
-		namespaces := make([]string, 0, len(services.Items))
-		for _, svc := range services.Items {
-			namespaces = append(namespaces, svc.Namespace)
-		}
-		sort.Strings(namespaces)
-		return nil, fmt.Errorf(
-			"found %d backup-exporter services (label %s=%s), expected exactly 1: namespaces %s",
-			len(services.Items), backupExporterLabelKey, backupExporterLabelValue, strings.Join(namespaces, ", "))
-	}
+	return services.Items, nil
 }
 
 // fetchBackupStatus returns the raw GET /api/v1/backups response body, reached by port-forwarding
@@ -464,7 +485,81 @@ func formatLatestAge(r backupResource, collectedAt *time.Time, now time.Time) st
 	if age == nil {
 		return "-"
 	}
-	return duration.HumanDuration(*age)
+
+	return formatAge(*age)
+}
+
+// formatAge renders a backup age the way an operator reads a clock: at most two units, largest
+// first, a zero trailing unit elided - "45s", "45m", "2h 57m", "13h", "3d 4h". Follows
+// formatBootstrapDuration's style rather than k8s' duration.HumanDuration, which renders
+// everything under three hours as raw minutes ("177m").
+func formatAge(d time.Duration) string {
+	d = d.Round(time.Second)
+	if d < 0 {
+		d = 0
+	}
+
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", d/time.Second)
+
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", d/time.Minute)
+
+	case d < hoursPerDay*time.Hour:
+		if m := (d % time.Hour) / time.Minute; m > 0 {
+			return fmt.Sprintf("%dh %dm", d/time.Hour, m)
+		}
+
+		return fmt.Sprintf("%dh", d/time.Hour)
+
+	default:
+		if h := (d % (hoursPerDay * time.Hour)) / time.Hour; h > 0 {
+			return fmt.Sprintf("%dd %dh", d/(hoursPerDay*time.Hour), h)
+		}
+
+		return fmt.Sprintf("%dd", d/(hoursPerDay*time.Hour))
+	}
+}
+
+// hoursPerDay is the day boundary formatAge switches units at.
+const hoursPerDay = 24
+
+// backupOperatorCNPG is the operator name CNPG rows carry, the one whose streams are renamed
+// for display.
+const backupOperatorCNPG = "cnpg"
+
+// cnpgMethodByStream names the mechanism behind each CNPG stream, which the exporter itself does
+// not report: the logical backup is taken by a CronJob, the WAL archive by the barman-cloud
+// plugin declared in the Cluster CR. Spelled the way each names itself, as Velero's methods are.
+var cnpgMethodByStream = map[string]string{
+	"logical": "CronJob",
+	"wal":     "Barman",
+}
+
+// resourceMethod returns how a resource's backup is taken, or "" when nothing names it. Velero
+// reports its own method; CNPG reports none, so the mechanism behind the stream stands in. A CNPG
+// stream added later yields "" rather than a guessed mechanism.
+func resourceMethod(r backupResource) string {
+	if r.Method != "" {
+		return r.Method
+	}
+
+	if r.Operator == backupOperatorCNPG {
+		return cnpgMethodByStream[r.Stream]
+	}
+
+	return ""
+}
+
+// formatMethod renders a resource's METHOD cell, carrying Velero's own method names through
+// verbatim ("PodVolumeBackup", "CSISnapshot") so they match what Velero's CRs and docs call them.
+func formatMethod(r backupResource) string {
+	if method := resourceMethod(r); method != "" {
+		return method
+	}
+
+	return "-"
 }
 
 // formatStatus renders a resource's STATUS cell, folding error_type into collector_error rows
@@ -504,7 +599,7 @@ func formatCollectorHeader(collectors []backupCollector, now time.Time) string {
 	for _, c := range collectors {
 		age := collectorNeverCollected
 		if c.CollectedAt != nil {
-			age = duration.HumanDuration(now.Sub(*c.CollectedAt)) + " ago"
+			age = formatAge(now.Sub(*c.CollectedAt)) + " ago"
 		}
 		if len(ages) > 0 && age != ages[0] {
 			shared = false
@@ -540,19 +635,59 @@ var statusOrder = []string{
 	backupStatusUnknown,
 }
 
-// countByStatus tallies resources per reported status.
-func countByStatus(resources []backupResource) map[string]int {
-	counts := make(map[string]int, len(resources))
-	for _, r := range resources {
-		counts[r.Status]++
-	}
-	return counts
+// statusSeverity ranks statuses worst first, for folding a resource's per-stream rows into the
+// single status the summary counts it under.
+var statusSeverity = []string{
+	backupStatusNoBackup,
+	backupStatusExceedsRPO,
+	backupStatusCollectorError,
+	backupStatusUnknown,
+	backupStatusHealthy,
 }
 
-// formatStatusSummary renders counts as "N healthy, M exceeds_rpo, ...", ordered by
+// severityRank places a status in statusSeverity, lower being worse. A status not listed there
+// (schema drift) ranks worst of all, so a new status is never quietly folded under a healthier
+// one.
+func severityRank(status string) int {
+	for i, s := range statusSeverity {
+		if s == status {
+			return i
+		}
+	}
+
+	return -1
+}
+
+// resourceKey identifies the resource a row reports on; rows sharing it differ only by stream.
+func resourceKey(r backupResource) string {
+	return r.Namespace + "/" + r.ResourceName + "/" + r.ResourceType
+}
+
+// countByStatus tallies resources - not rows - per status, each counted once under its worst
+// stream status, and returns the resource total alongside. A CNPG cluster with no logical backup
+// and a failed wal check is one no_backup resource, not one no_backup plus one collector_error:
+// summing per-stream rows double-counts the same resource under several statuses.
+func countByStatus(resources []backupResource) (map[string]int, int) {
+	worst := make(map[string]string, len(resources))
+	for _, r := range resources {
+		key := resourceKey(r)
+		if current, seen := worst[key]; !seen || severityRank(r.Status) < severityRank(current) {
+			worst[key] = r.Status
+		}
+	}
+
+	counts := make(map[string]int, len(worst))
+	for _, status := range worst {
+		counts[status]++
+	}
+
+	return counts, len(worst)
+}
+
+// formatStatusSummary renders counts as "12 resources: 8 healthy, 4 no_backup", ordered by
 // statusOrder with any status outside it (schema drift) sorted after - every count is shown,
 // none dropped silently.
-func formatStatusSummary(counts map[string]int) string {
+func formatStatusSummary(counts map[string]int, total int) string {
 	known := make(map[string]bool, len(statusOrder))
 	parts := make([]string, 0, len(counts))
 	for _, s := range statusOrder {
@@ -576,7 +711,13 @@ func formatStatusSummary(counts map[string]int) string {
 	if len(parts) == 0 {
 		return "no resources reported"
 	}
-	return strings.Join(parts, ", ")
+
+	noun := "resources"
+	if total == 1 {
+		noun = "resource"
+	}
+
+	return fmt.Sprintf("%d %s: %s", total, noun, strings.Join(parts, ", "))
 }
 
 // sortResources orders resources by namespace then resource name (the display contract),
@@ -601,14 +742,15 @@ func sortResources(resources []backupResource) {
 	})
 }
 
-// anyMethod reports whether any resource carries a backup method, so the Velero-only METHOD
-// column can be omitted entirely when every row would leave it blank.
+// anyMethod reports whether any resource has a method to show, so the METHOD column can be
+// omitted entirely when every row would leave it blank.
 func anyMethod(resources []backupResource) bool {
 	for _, r := range resources {
-		if r.Method != "" {
+		if resourceMethod(r) != "" {
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -636,11 +778,7 @@ func renderResourceTable(resources []backupResource, collectedAt map[string]*tim
 	for _, r := range sorted {
 		row := []string{r.Namespace, r.ResourceName, r.ResourceType, r.Stream}
 		if showMethod {
-			method := r.Method
-			if method == "" {
-				method = "-"
-			}
-			row = append(row, method)
+			row = append(row, formatMethod(r))
 		}
 		row = append(row, formatLatestAge(r, collectedAt[r.Operator], now), formatStatus(r))
 

--- a/pkg/core/backup_status.go
+++ b/pkg/core/backup_status.go
@@ -1,0 +1,680 @@
+// Copyright 2026 Obmondo
+// SPDX-License-Identifier: AGPL3
+
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	coreV1 "k8s.io/api/core/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/duration"
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	k8sclientset "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+	"k8s.io/kubectl/pkg/util/podutils"
+
+	"github.com/Obmondo/kubeaid-cli/pkg/utils/assert"
+	"github.com/Obmondo/kubeaid-cli/pkg/utils/kubernetes"
+)
+
+// Status values reported for a backup resource by backup-exporter's GET /api/v1/backups.
+// Mirrors backup-exporter's pkg/api — that module is not imported, kubeaid-cli only speaks its
+// wire format.
+const (
+	backupStatusHealthy        = "healthy"
+	backupStatusExceedsRPO     = "exceeds_rpo"
+	backupStatusNoBackup       = "no_backup"
+	backupStatusCollectorError = "collector_error"
+	backupStatusUnknown        = "unknown"
+)
+
+// outputFormatJSON is the only accepted --output value.
+const outputFormatJSON = "json"
+
+// Resource-table column padding, matching kubectl's own printer
+// (k8s.io/cli-runtime/pkg/printers.GetNewTabWriter).
+const (
+	tabwriterMinWidth = 6
+	tabwriterTabWidth = 4
+	tabwriterPadding  = 3
+)
+
+// backup-exporter's Service coordinates: the label its Helm chart stamps on the Service, the
+// name its chart is expected to give the Service port that serves backupExporterAPIPath, and
+// that HTTP path itself.
+const (
+	backupExporterLabelKey        = "app.kubernetes.io/name"
+	backupExporterLabelValue      = "backup-exporter"
+	backupExporterServicePortName = "http"
+	backupExporterAPIPath         = "/api/v1/backups"
+)
+
+// portForwardReadyTimeout bounds how long fetchViaPortForward waits for the tunnel to come up
+// before giving up - a dial that never resolves (e.g. a proxy silently dropping the upgrade)
+// must not hang the CLI forever.
+const portForwardReadyTimeout = 15 * time.Second
+
+// backupExporterFetchTimeout bounds the HTTP GET issued over an established port-forward
+// tunnel, independent of portForwardReadyTimeout, which only covers dialing.
+const backupExporterFetchTimeout = 10 * time.Second
+
+// backupCollector reports when an operator last finished a collection run. CollectedAt is nil
+// when it has not completed a run yet, distinct from an operator that ran and found nothing.
+// Every resource age below was measured at this timestamp, not at request time.
+type backupCollector struct {
+	Operator    string     `json:"operator"`
+	CollectedAt *time.Time `json:"collected_at"`
+}
+
+// backupResource is one backup stream of one operator's backups for one resource. The age
+// fields are nil when no series was published for them, distinct from a reported age of
+// exactly zero (the operators' shared "no backup exists" sentinel).
+type backupResource struct {
+	Operator               string   `json:"operator"`
+	Stream                 string   `json:"stream"`
+	Namespace              string   `json:"namespace"`
+	ResourceName           string   `json:"resource_name"`
+	ResourceType           string   `json:"resource_type"`
+	Method                 string   `json:"method,omitempty"`
+	LatestBackupAgeSeconds *float64 `json:"latest_backup_age_seconds"`
+	OldestBackupAgeSeconds *float64 `json:"oldest_backup_age_seconds"`
+	MaxIntervalSeconds     *float64 `json:"max_interval_seconds"`
+	Status                 string   `json:"status"`
+	ErrorType              string   `json:"error_type,omitempty"`
+}
+
+// backupOperatorError is a collector failure with no resource identity (e.g. Velero failing to
+// list its S3 bucket), so it can't be attached to a resource row.
+type backupOperatorError struct {
+	Operator string `json:"operator"`
+	Type     string `json:"type"`
+}
+
+// backupResponse is the GET /api/v1/backups response body.
+type backupResponse struct {
+	Collectors     []backupCollector     `json:"collectors"`
+	Resources      []backupResource      `json:"resources"`
+	OperatorErrors []backupOperatorError `json:"operator_errors,omitempty"`
+}
+
+// BackupStatus fetches backup health from backup-exporter's JSON API and prints it.
+// outputFormat "json" dumps the raw API response verbatim; any other value (including "")
+// renders the human-readable report. Exits non-zero only when the fetch or decode itself
+// fails - reported backup statuses (healthy/exceeds_rpo/no_backup/...) never affect the exit
+// code.
+func BackupStatus(ctx context.Context, outputFormat string) {
+	// The current kubeconfig, exactly like kubectl: a status command must not
+	// depend on the KubeOne artifact, whose endpoint is only reachable through
+	// the provisioning SSH tunnel.
+	clientset, err := kubernetes.CreateClientset(ctx)
+	assert.AssertErrNil(ctx, err, "Failed constructing cluster client from your kubeconfig")
+
+	// The port-forward dialer needs the raw *rest.Config (auth/TLS transport details) that
+	// clientset itself doesn't expose.
+	restConfig, err := kubernetes.CreateRESTConfig(ctx)
+	assert.AssertErrNil(ctx, err, "Failed constructing cluster client from your kubeconfig")
+
+	body, err := fetchBackupStatus(ctx, clientset, restConfig)
+	assert.AssertErrNil(ctx, err, "Failed fetching backup status from backup-exporter")
+
+	if outputFormat == outputFormatJSON {
+		_, err := os.Stdout.Write(body) //nolint:forbidigo // verbatim API passthrough, not a log line
+		assert.AssertErrNil(ctx, err, "Failed writing backup status JSON to stdout")
+		return
+	}
+
+	var response backupResponse
+	err = json.Unmarshal(body, &response)
+	assert.AssertErrNil(ctx, err, "Failed decoding backup-exporter response")
+
+	fmt.Print(renderBackupStatus(response, time.Now())) //nolint:forbidigo // operator-facing terminal output
+}
+
+// findBackupExporterService locates backup-exporter's Service by label across every
+// namespace. Errors when none or more than one match, naming the namespaces found so the
+// operator knows what to look at. Returns the full Service (not just its namespace/name) so
+// callers needing .Spec.Selector or .Spec.Ports - port-forwarding does - don't need a second
+// List/Get round trip, and RBAC stays to `list` on services rather than also needing `get`.
+func findBackupExporterService(ctx context.Context, clientset k8sclientset.Interface) (*coreV1.Service, error) {
+	services, err := clientset.CoreV1().Services(metaV1.NamespaceAll).List(ctx, metaV1.ListOptions{
+		LabelSelector: backupExporterLabelKey + "=" + backupExporterLabelValue,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed listing services labeled %s=%s: %w",
+			backupExporterLabelKey, backupExporterLabelValue, err)
+	}
+
+	switch len(services.Items) {
+	case 0:
+		return nil, fmt.Errorf(
+			"no backup-exporter service found (label %s=%s) in any namespace; is the backup-exporter chart installed?",
+			backupExporterLabelKey, backupExporterLabelValue)
+
+	case 1:
+		svc := services.Items[0]
+		return &svc, nil
+
+	default:
+		namespaces := make([]string, 0, len(services.Items))
+		for _, svc := range services.Items {
+			namespaces = append(namespaces, svc.Namespace)
+		}
+		sort.Strings(namespaces)
+		return nil, fmt.Errorf(
+			"found %d backup-exporter services (label %s=%s), expected exactly 1: namespaces %s",
+			len(services.Items), backupExporterLabelKey, backupExporterLabelValue, strings.Join(namespaces, ", "))
+	}
+}
+
+// fetchBackupStatus returns the raw GET /api/v1/backups response body, reached by port-forwarding
+// to backup-exporter's pod - the pods/portforward subresource, the same mechanism `kubectl
+// port-forward` uses. Unlike the services/proxy subresource this survives L7 API-server proxies
+// (e.g. netbird's ClusterProxy) that 404 on services/proxy but pass through the upgraded
+// SPDY/WebSocket stream pods/portforward negotiates.
+func fetchBackupStatus(ctx context.Context, clientset k8sclientset.Interface, restConfig *restclient.Config) ([]byte, error) {
+	svc, err := findBackupExporterService(ctx, clientset)
+	if err != nil {
+		return nil, err
+	}
+
+	pod, err := findReadyPod(ctx, clientset, svc.Namespace, svc.Name, svc.Spec.Selector)
+	if err != nil {
+		return nil, err
+	}
+
+	targetPort, err := resolveTargetPort(svc, pod)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := fetchViaPortForward(ctx, clientset, restConfig, svc.Namespace, pod.Name, targetPort)
+	if err != nil {
+		return nil, fmt.Errorf("failed fetching %s from backup-exporter pod %s/%s: %w",
+			backupExporterAPIPath, svc.Namespace, pod.Name, err)
+	}
+	return body, nil
+}
+
+// findReadyPod lists pods in namespace matching selector - a Service's own .spec.selector, so
+// this works regardless of a chart's label scheme rather than assuming backup-exporter's - and
+// returns the first one that's Running with a Ready=True condition. Mirrors the readiness bar
+// `kubectl port-forward service/...` applies when resolving a Service target to a pod.
+func findReadyPod(ctx context.Context, clientset k8sclientset.Interface, namespace, serviceName string, selector map[string]string) (*coreV1.Pod, error) {
+	if len(selector) == 0 {
+		return nil, fmt.Errorf("service %s/%s has no pod selector", namespace, serviceName)
+	}
+
+	pods, err := clientset.CoreV1().Pods(namespace).List(ctx, metaV1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(selector).String(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed listing pods for service %s/%s: %w", namespace, serviceName, err)
+	}
+
+	for i := range pods.Items {
+		if podReady(&pods.Items[i]) {
+			return &pods.Items[i], nil
+		}
+	}
+	return nil, fmt.Errorf("no ready pod behind service %s/%s", namespace, serviceName)
+}
+
+// podReady reports whether pod is Running with a Ready=True condition - the same bar argo-cd's
+// own port-forward pod selection uses (argo-cd/v2/util/kube.selectPodForPortForward, reached
+// transitively via pkg/apiclient's PortForward option elsewhere in this codebase), and Ready
+// alone isn't a substitute for: podutils.IsPodReady only inspects the condition, so a
+// Succeeded/Failed pod that never cleared a stale Ready=True still needs the Phase check.
+func podReady(pod *coreV1.Pod) bool {
+	return pod.Status.Phase == coreV1.PodRunning && podutils.IsPodReady(pod)
+}
+
+// resolveTargetPort picks backup-exporter's Service port (named "http", or the Service's only
+// port) and resolves it to a container port on pod: a numeric TargetPort is used directly, a
+// named one is looked up by container port name, and an omitted TargetPort defaults to the
+// Service's Port. Mirrors k8s.io/kubectl/pkg/util's target-port resolution semantics (that
+// package's lookup helpers take value types tied to kubectl's own command options, so this
+// reimplements rather than imports them).
+func resolveTargetPort(svc *coreV1.Service, pod *coreV1.Pod) (int32, error) {
+	svcPort, err := backupExporterServicePort(svc)
+	if err != nil {
+		return 0, err
+	}
+
+	switch {
+	case svcPort.TargetPort.Type == intstr.String:
+		return containerPortByName(pod, svcPort.TargetPort.StrVal)
+	case svcPort.TargetPort.IntVal != 0:
+		return svcPort.TargetPort.IntVal, nil
+	default:
+		// TargetPort omitted: Kubernetes defaults it to Port.
+		return svcPort.Port, nil
+	}
+}
+
+// backupExporterServicePort picks svc's port named backupExporterServicePortName, falling back
+// to its only port when it declares just one (named or not) - the shape backup-exporter's chart
+// is expected to use either way.
+func backupExporterServicePort(svc *coreV1.Service) (coreV1.ServicePort, error) {
+	if len(svc.Spec.Ports) == 1 {
+		return svc.Spec.Ports[0], nil
+	}
+	for _, port := range svc.Spec.Ports {
+		if port.Name == backupExporterServicePortName {
+			return port, nil
+		}
+	}
+	return coreV1.ServicePort{}, fmt.Errorf(
+		"service %s/%s has %d ports and none named %q",
+		svc.Namespace, svc.Name, len(svc.Spec.Ports), backupExporterServicePortName)
+}
+
+// containerPortByName looks up a named container port across pod's containers.
+func containerPortByName(pod *coreV1.Pod, name string) (int32, error) {
+	for _, container := range pod.Spec.Containers {
+		for _, port := range container.Ports {
+			if port.Name == name {
+				return port.ContainerPort, nil
+			}
+		}
+	}
+	return 0, fmt.Errorf("pod %s/%s has no container port named %q", pod.Namespace, pod.Name, name)
+}
+
+// newPortForwardDialer builds the same dialer `kubectl port-forward` does (see
+// k8s.io/kubectl/pkg/cmd/portforward's createDialer - unexported, so mirrored here rather than
+// imported): a WebSocket-tunneled SPDY dialer tried first, falling back to plain SPDY when the
+// upgrade itself fails or an HTTPS-terminating proxy gets in the way. The WebSocket path is
+// what lets this survive L7 API-server proxies (e.g. netbird's ClusterProxy) that don't speak
+// raw SPDY upgrades.
+func newPortForwardDialer(clientset k8sclientset.Interface, restConfig *restclient.Config, namespace, podName string) (httpstream.Dialer, error) {
+	portForwardURL := clientset.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Namespace(namespace).
+		Name(podName).
+		SubResource("portforward").
+		URL()
+
+	transport, upgrader, err := spdy.RoundTripperFor(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed building SPDY round tripper: %w", err)
+	}
+	spdyDialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, http.MethodPost, portForwardURL)
+
+	websocketDialer, err := portforward.NewSPDYOverWebsocketDialer(portForwardURL, restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed building WebSocket dialer: %w", err)
+	}
+
+	return portforward.NewFallbackDialer(websocketDialer, spdyDialer, func(err error) bool {
+		return httpstream.IsUpgradeFailure(err) || httpstream.IsHTTPSProxyError(err)
+	}), nil
+}
+
+// fetchViaPortForward opens a port-forward to pod's targetPort, fetches backupExporterAPIPath
+// over it, and tears the tunnel down before returning either way.
+func fetchViaPortForward(ctx context.Context, clientset k8sclientset.Interface, restConfig *restclient.Config, namespace, podName string, targetPort int32) ([]byte, error) {
+	dialer, err := newPortForwardDialer(clientset, restConfig, namespace, podName)
+	if err != nil {
+		return nil, fmt.Errorf("failed constructing port-forward dialer for pod %s/%s: %w", namespace, podName, err)
+	}
+
+	stopChan := make(chan struct{})
+	readyChan := make(chan struct{})
+
+	// Suppress the forwarder's own "Forwarding from ..." / "Handling connection ..." lines -
+	// they'd otherwise land on stdout ahead of the table this command prints. Failures are
+	// reported through the returned error instead.
+	forwarder, err := portforward.New(dialer,
+		[]string{fmt.Sprintf("0:%d", targetPort)},
+		stopChan, readyChan,
+		io.Discard, io.Discard,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed constructing port-forwarder for pod %s/%s: %w", namespace, podName, err)
+	}
+
+	forwardErrChan := make(chan error, 1)
+	go func() {
+		forwardErrChan <- forwarder.ForwardPorts()
+	}()
+
+	select {
+	case <-readyChan:
+
+	case err := <-forwardErrChan:
+		return nil, fmt.Errorf("port-forward to pod %s/%s failed before becoming ready: %w", namespace, podName, err)
+
+	case <-time.After(portForwardReadyTimeout):
+		// dialer.Dial may still be blocked in-flight here - this is exactly the "proxy
+		// silently drops the upgrade" failure this whole path exists to survive - and
+		// forward()'s stopChan-select is only reached once Dial returns. Draining
+		// forwardErrChan would block on that same hang and defeat the timeout, so don't:
+		// close(stopChan) still stops it promptly if it's actually past dialing, and either
+		// way the goroutine's buffered send never blocks even with nothing left to read it.
+		close(stopChan)
+		return nil, fmt.Errorf("timed out after %s waiting for port-forward to pod %s/%s to become ready",
+			portForwardReadyTimeout, namespace, podName)
+
+	case <-ctx.Done():
+		// Same reasoning as the timeout case above: returning promptly on ctx cancellation
+		// must not depend on a goroutine that may still be stuck inside an in-flight Dial.
+		close(stopChan)
+		return nil, fmt.Errorf("port-forward to pod %s/%s cancelled: %w", namespace, podName, ctx.Err())
+	}
+
+	ports, err := forwarder.GetPorts()
+	if err != nil {
+		close(stopChan)
+		<-forwardErrChan
+		return nil, fmt.Errorf("failed reading forwarded local port for pod %s/%s: %w", namespace, podName, err)
+	}
+	if len(ports) == 0 {
+		close(stopChan)
+		<-forwardErrChan
+		return nil, fmt.Errorf("port-forward to pod %s/%s reported no forwarded ports", namespace, podName)
+	}
+
+	body, fetchErr := getBackupsOverLocalPort(ctx, ports[0].Local)
+
+	close(stopChan)
+	forwardErr := <-forwardErrChan
+
+	if fetchErr != nil {
+		return nil, fetchErr
+	}
+	// A stopChan-triggered shutdown returns nil from ForwardPorts. ErrLostConnectionToPod means
+	// the remote side closed at roughly the same moment we asked it to - which happened after
+	// getBackupsOverLocalPort already had its answer, so it isn't a real failure here.
+	if forwardErr != nil && !errors.Is(forwardErr, portforward.ErrLostConnectionToPod) {
+		return nil, fmt.Errorf("port-forward to pod %s/%s failed: %w", namespace, podName, forwardErr)
+	}
+
+	return body, nil
+}
+
+// getBackupsOverLocalPort fetches backupExporterAPIPath from the local end of an established
+// port-forward tunnel, bounding the request with backupExporterFetchTimeout independent of the
+// caller's own deadline.
+func getBackupsOverLocalPort(ctx context.Context, localPort uint16) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, backupExporterFetchTimeout)
+	defer cancel()
+
+	fetchURL := fmt.Sprintf("http://127.0.0.1:%d%s", localPort, backupExporterAPIPath)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fetchURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed building request for %s: %w", fetchURL, err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed fetching %s: %w", fetchURL, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed reading response body from %s: %w", fetchURL, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d from %s: %s", resp.StatusCode, fetchURL, string(body))
+	}
+
+	return body, nil
+}
+
+// adjustedAge converts a backup age sampled at collectedAt into a duration as of now, per
+// backup-exporter's contract: ages are measured when a collector runs, not when the API is
+// called. Returns nil when there is no age to adjust (nil ageSeconds) or no reference point to
+// adjust it from (nil collectedAt) - the latter shouldn't occur for a real resource, but
+// showing nothing beats silently understating the true age.
+func adjustedAge(ageSeconds *float64, collectedAt *time.Time, now time.Time) *time.Duration {
+	if ageSeconds == nil || collectedAt == nil {
+		return nil
+	}
+	adjusted := time.Duration(*ageSeconds*float64(time.Second)) + now.Sub(*collectedAt)
+	return &adjusted
+}
+
+// formatLatestAge renders a resource's LATEST AGE cell: "-" when no series was published for
+// it, "none" for the operators' shared no-backup sentinel (a reported age of exactly zero),
+// otherwise the humanized, collector-adjusted age.
+func formatLatestAge(r backupResource, collectedAt *time.Time, now time.Time) string {
+	if r.LatestBackupAgeSeconds == nil {
+		return "-"
+	}
+	if *r.LatestBackupAgeSeconds == 0 {
+		return "none"
+	}
+	age := adjustedAge(r.LatestBackupAgeSeconds, collectedAt, now)
+	if age == nil {
+		return "-"
+	}
+	return duration.HumanDuration(*age)
+}
+
+// formatStatus renders a resource's STATUS cell, folding error_type into collector_error rows
+// so the failure reason is visible without a dedicated column.
+func formatStatus(r backupResource) string {
+	if r.Status == backupStatusCollectorError && r.ErrorType != "" {
+		return fmt.Sprintf("%s (%s)", r.Status, r.ErrorType)
+	}
+	return r.Status
+}
+
+// collectedAtByOperator indexes collectors by operator name, for per-resource age adjustment.
+func collectedAtByOperator(collectors []backupCollector) map[string]*time.Time {
+	result := make(map[string]*time.Time, len(collectors))
+	for _, c := range collectors {
+		result[c.Operator] = c.CollectedAt
+	}
+	return result
+}
+
+// collectorNeverCollected is the age stand-in for a collector that has not completed a run.
+const collectorNeverCollected = "never"
+
+// formatCollectorHeader condenses collector freshness into a single line: "collected 5m ago:
+// cnpg | velero" when every collector reports the same age, otherwise per-operator ages. A
+// collector that has never completed a run is named rather than dropped, so a silent operator
+// cannot hide behind its peers' freshness.
+func formatCollectorHeader(collectors []backupCollector, now time.Time) string {
+	if len(collectors) == 0 {
+		return "no collectors reported"
+	}
+
+	names := make([]string, 0, len(collectors))
+	ages := make([]string, 0, len(collectors))
+	shared := true
+
+	for _, c := range collectors {
+		age := collectorNeverCollected
+		if c.CollectedAt != nil {
+			age = duration.HumanDuration(now.Sub(*c.CollectedAt)) + " ago"
+		}
+		if len(ages) > 0 && age != ages[0] {
+			shared = false
+		}
+
+		names = append(names, c.Operator)
+		ages = append(ages, age)
+	}
+
+	if shared {
+		if ages[0] == collectorNeverCollected {
+			return "no completed collection run yet: " + strings.Join(names, " | ")
+		}
+
+		return fmt.Sprintf("collected %s: %s", ages[0], strings.Join(names, " | "))
+	}
+
+	parts := make([]string, 0, len(collectors))
+	for i, name := range names {
+		parts = append(parts, name+" "+ages[i])
+	}
+
+	return "collected: " + strings.Join(parts, " | ")
+}
+
+// statusOrder is the display order for the summary line: healthy first, then the statuses
+// that need operator attention.
+var statusOrder = []string{
+	backupStatusHealthy,
+	backupStatusExceedsRPO,
+	backupStatusNoBackup,
+	backupStatusCollectorError,
+	backupStatusUnknown,
+}
+
+// countByStatus tallies resources per reported status.
+func countByStatus(resources []backupResource) map[string]int {
+	counts := make(map[string]int, len(resources))
+	for _, r := range resources {
+		counts[r.Status]++
+	}
+	return counts
+}
+
+// formatStatusSummary renders counts as "N healthy, M exceeds_rpo, ...", ordered by
+// statusOrder with any status outside it (schema drift) sorted after - every count is shown,
+// none dropped silently.
+func formatStatusSummary(counts map[string]int) string {
+	known := make(map[string]bool, len(statusOrder))
+	parts := make([]string, 0, len(counts))
+	for _, s := range statusOrder {
+		known[s] = true
+		if n := counts[s]; n > 0 {
+			parts = append(parts, fmt.Sprintf("%d %s", n, s))
+		}
+	}
+
+	extra := make([]string, 0, len(counts))
+	for s, n := range counts {
+		if !known[s] && n > 0 {
+			extra = append(extra, s)
+		}
+	}
+	sort.Strings(extra)
+	for _, s := range extra {
+		parts = append(parts, fmt.Sprintf("%d %s", counts[s], s))
+	}
+
+	if len(parts) == 0 {
+		return "no resources reported"
+	}
+	return strings.Join(parts, ", ")
+}
+
+// sortResources orders resources by namespace then resource name (the display contract),
+// falling back to operator/stream/method so rows sharing a namespace+name (e.g. a CNPG
+// cluster's logical and wal streams) render in a stable order across runs.
+func sortResources(resources []backupResource) {
+	sort.Slice(resources, func(i, j int) bool {
+		a, b := resources[i], resources[j]
+		if a.Namespace != b.Namespace {
+			return a.Namespace < b.Namespace
+		}
+		if a.ResourceName != b.ResourceName {
+			return a.ResourceName < b.ResourceName
+		}
+		if a.Operator != b.Operator {
+			return a.Operator < b.Operator
+		}
+		if a.Stream != b.Stream {
+			return a.Stream < b.Stream
+		}
+		return a.Method < b.Method
+	})
+}
+
+// anyMethod reports whether any resource carries a backup method, so the Velero-only METHOD
+// column can be omitted entirely when every row would leave it blank.
+func anyMethod(resources []backupResource) bool {
+	for _, r := range resources {
+		if r.Method != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// renderResourceTable lays resources out as a plain aligned table, sorted per sortResources:
+// an uppercase header row and one row per backup stream, the shape kubectl prints. The METHOD
+// column appears only when at least one resource carries a method.
+func renderResourceTable(resources []backupResource, collectedAt map[string]*time.Time, now time.Time) string {
+	sorted := make([]backupResource, len(resources))
+	copy(sorted, resources)
+	sortResources(sorted)
+
+	showMethod := anyMethod(sorted)
+
+	headers := []string{"NAMESPACE", "RESOURCE", "TYPE", "STREAM"}
+	if showMethod {
+		headers = append(headers, "METHOD")
+	}
+	headers = append(headers, "LATEST AGE", "STATUS")
+
+	var b strings.Builder
+
+	w := tabwriter.NewWriter(&b, tabwriterMinWidth, tabwriterTabWidth, tabwriterPadding, ' ', 0)
+	fmt.Fprintln(w, strings.Join(headers, "\t"))
+
+	for _, r := range sorted {
+		row := []string{r.Namespace, r.ResourceName, r.ResourceType, r.Stream}
+		if showMethod {
+			method := r.Method
+			if method == "" {
+				method = "-"
+			}
+			row = append(row, method)
+		}
+		row = append(row, formatLatestAge(r, collectedAt[r.Operator], now), formatStatus(r))
+
+		fmt.Fprintln(w, strings.Join(row, "\t"))
+	}
+
+	// Flush only fails when the underlying writer does, and a strings.Builder never does.
+	_ = w.Flush()
+
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// renderBackupStatus assembles the full human-readable report: a single collector freshness
+// line, any operator errors, the resource table, then the status-count summary line.
+// Returns a string rather than printing directly so the formatting itself stays testable.
+func renderBackupStatus(resp backupResponse, now time.Time) string {
+	var b strings.Builder
+
+	fmt.Fprintln(&b, formatCollectorHeader(resp.Collectors, now))
+
+	if len(resp.OperatorErrors) > 0 {
+		fmt.Fprintln(&b, "\nOperator errors:")
+		for _, e := range resp.OperatorErrors {
+			fmt.Fprintf(&b, "  %s: %s\n", e.Operator, e.Type)
+		}
+	}
+
+	// A headers-only table adds nothing beyond what "no resources reported" already says.
+	if len(resp.Resources) > 0 {
+		fmt.Fprintln(&b)
+		fmt.Fprintln(&b, renderResourceTable(resp.Resources, collectedAtByOperator(resp.Collectors), now))
+	}
+
+	fmt.Fprintln(&b, formatStatusSummary(countByStatus(resp.Resources)))
+
+	return b.String()
+}

--- a/pkg/core/backup_status_test.go
+++ b/pkg/core/backup_status_test.go
@@ -6,6 +6,7 @@ package core
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -17,10 +18,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	coreV1 "k8s.io/api/core/v1"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
 	restclient "k8s.io/client-go/rest"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 func floatPtr(f float64) *float64                { return &f }
@@ -102,7 +106,7 @@ func TestFormatLatestAge(t *testing.T) {
 			name:        "normal age is humanized and adjusted for elapsed collection time",
 			resource:    backupResource{LatestBackupAgeSeconds: floatPtr(3 * 3600)},
 			collectedAt: timePtr(collectedAt),
-			expected:    "3h10m", // 3h at collection + 10m elapsed since = 3h10m
+			expected:    "3h 10m", // 3h at collection + 10m elapsed since
 		},
 		{
 			name:        "non-nil age but nil collected_at renders as - (can't safely adjust)",
@@ -115,6 +119,31 @@ func TestFormatLatestAge(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.expected, formatLatestAge(tc.resource, tc.collectedAt, now))
+		})
+	}
+}
+
+func TestFormatAge(t *testing.T) {
+	testCases := []struct {
+		name     string
+		duration time.Duration
+		expected string
+	}{
+		{name: "sub-minute keeps seconds", duration: 45 * time.Second, expected: "45s"},
+		{name: "negative clamps to zero", duration: -3 * time.Second, expected: "0s"},
+		{name: "a minute drops seconds", duration: 90 * time.Second, expected: "1m"},
+		{name: "under an hour is minutes", duration: 45 * time.Minute, expected: "45m"},
+		{name: "the case kubectl renders as 177m", duration: 177 * time.Minute, expected: "2h 57m"},
+		{name: "a whole hour drops the minutes", duration: time.Hour, expected: "1h"},
+		{name: "13h stays 13h", duration: 13 * time.Hour, expected: "13h"},
+		{name: "just under a day", duration: 23*time.Hour + 59*time.Minute, expected: "23h 59m"},
+		{name: "a day drops the hours", duration: 24 * time.Hour, expected: "1d"},
+		{name: "days carry hours, never minutes", duration: 3*24*time.Hour + 4*time.Hour + 30*time.Minute, expected: "3d 4h"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, formatAge(tc.duration))
 		})
 	}
 }
@@ -147,7 +176,7 @@ func TestFormatCollectorHeader(t *testing.T) {
 				{Operator: "cnpg", CollectedAt: timePtr(now.Add(-87 * time.Minute))},
 				{Operator: "velero", CollectedAt: timePtr(now.Add(-87 * time.Minute))},
 			},
-			expected: "collected 87m ago: cnpg | velero",
+			expected: "collected 1h 27m ago: cnpg | velero",
 		},
 		{
 			name: "differing ages are reported per operator",
@@ -155,7 +184,7 @@ func TestFormatCollectorHeader(t *testing.T) {
 				{Operator: "cnpg", CollectedAt: timePtr(now.Add(-87 * time.Minute))},
 				{Operator: "velero", CollectedAt: timePtr(now.Add(-5 * time.Minute))},
 			},
-			expected: "collected: cnpg 87m ago | velero 5m ago",
+			expected: "collected: cnpg 1h 27m ago | velero 5m ago",
 		},
 		{
 			name: "a collector that never ran is named beside one that has",
@@ -183,28 +212,67 @@ func TestFormatCollectorHeader(t *testing.T) {
 }
 
 func TestCountByStatus(t *testing.T) {
-	resources := []backupResource{
-		{Status: backupStatusHealthy},
-		{Status: backupStatusHealthy},
-		{Status: backupStatusExceedsRPO},
-		{Status: backupStatusNoBackup},
-		{Status: backupStatusNoBackup},
-		{Status: backupStatusNoBackup},
-	}
+	t.Run("each resource counts once, under its worst stream status", func(t *testing.T) {
+		resources := []backupResource{
+			// A missing logical backup and a failed wal check on one cluster is one resource
+			// in trouble, not one no_backup plus one collector_error.
+			{Namespace: "demo", ResourceName: "pgsql", ResourceType: "cnpg_cluster", Stream: "logical", Status: backupStatusNoBackup},
+			{Namespace: "demo", ResourceName: "pgsql", ResourceType: "cnpg_cluster", Stream: "wal", Status: backupStatusCollectorError},
+			{Namespace: "demo", ResourceName: "uploads", ResourceType: "pvc", Stream: "volume", Status: backupStatusHealthy},
+			{Namespace: "other", ResourceName: "pgsql", ResourceType: "cnpg_cluster", Stream: "logical", Status: backupStatusExceedsRPO},
+		}
 
-	counts := countByStatus(resources)
+		counts, total := countByStatus(resources)
 
-	assert.Equal(t, map[string]int{
-		backupStatusHealthy:    2,
-		backupStatusExceedsRPO: 1,
-		backupStatusNoBackup:   3,
-	}, counts)
+		assert.Equal(t, 3, total)
+		assert.Equal(t, map[string]int{
+			backupStatusNoBackup:   1,
+			backupStatusHealthy:    1,
+			backupStatusExceedsRPO: 1,
+		}, counts)
+	})
+
+	t.Run("a healthy stream never masks a failing one", func(t *testing.T) {
+		resources := []backupResource{
+			{Namespace: "demo", ResourceName: "pgsql", ResourceType: "cnpg_cluster", Stream: "wal", Status: backupStatusHealthy},
+			{Namespace: "demo", ResourceName: "pgsql", ResourceType: "cnpg_cluster", Stream: "logical", Status: backupStatusNoBackup},
+		}
+
+		counts, total := countByStatus(resources)
+
+		assert.Equal(t, 1, total)
+		assert.Equal(t, map[string]int{backupStatusNoBackup: 1}, counts)
+	})
+
+	t.Run("resources sharing a name in different namespaces stay separate", func(t *testing.T) {
+		resources := []backupResource{
+			{Namespace: "demo-a", ResourceName: "pgsql", ResourceType: "cnpg_cluster", Stream: "logical", Status: backupStatusHealthy},
+			{Namespace: "demo-b", ResourceName: "pgsql", ResourceType: "cnpg_cluster", Stream: "logical", Status: backupStatusHealthy},
+		}
+
+		counts, total := countByStatus(resources)
+
+		assert.Equal(t, 2, total)
+		assert.Equal(t, map[string]int{backupStatusHealthy: 2}, counts)
+	})
+
+	t.Run("an unrecognized status outranks every known one", func(t *testing.T) {
+		resources := []backupResource{
+			{Namespace: "demo", ResourceName: "pgsql", ResourceType: "cnpg_cluster", Stream: "logical", Status: backupStatusHealthy},
+			{Namespace: "demo", ResourceName: "pgsql", ResourceType: "cnpg_cluster", Stream: "wal", Status: "some_new_status"},
+		}
+
+		counts, _ := countByStatus(resources)
+
+		assert.Equal(t, map[string]int{"some_new_status": 1}, counts)
+	})
 }
 
 func TestFormatStatusSummary(t *testing.T) {
 	testCases := []struct {
 		name     string
 		counts   map[string]int
+		total    int
 		expected string
 	}{
 		{
@@ -213,13 +281,20 @@ func TestFormatStatusSummary(t *testing.T) {
 			expected: "no resources reported",
 		},
 		{
+			name:     "a single resource reads singular",
+			counts:   map[string]int{backupStatusHealthy: 1},
+			total:    1,
+			expected: "1 resource: 1 healthy",
+		},
+		{
 			name: "known statuses render in canonical order regardless of map order",
 			counts: map[string]int{
 				backupStatusNoBackup:   2,
 				backupStatusHealthy:    12,
 				backupStatusExceedsRPO: 1,
 			},
-			expected: "12 healthy, 1 exceeds_rpo, 2 no_backup",
+			total:    15,
+			expected: "15 resources: 12 healthy, 1 exceeds_rpo, 2 no_backup",
 		},
 		{
 			name: "all five known statuses",
@@ -230,7 +305,8 @@ func TestFormatStatusSummary(t *testing.T) {
 				backupStatusCollectorError: 1,
 				backupStatusUnknown:        1,
 			},
-			expected: "1 healthy, 1 exceeds_rpo, 1 no_backup, 1 collector_error, 1 unknown",
+			total:    5,
+			expected: "5 resources: 1 healthy, 1 exceeds_rpo, 1 no_backup, 1 collector_error, 1 unknown",
 		},
 		{
 			name: "unrecognized status is appended sorted, not dropped",
@@ -239,13 +315,14 @@ func TestFormatStatusSummary(t *testing.T) {
 				"weird_status":      1,
 				"another_status":    1,
 			},
-			expected: "1 healthy, 1 another_status, 1 weird_status",
+			total:    3,
+			expected: "3 resources: 1 healthy, 1 another_status, 1 weird_status",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expected, formatStatusSummary(tc.counts))
+			assert.Equal(t, tc.expected, formatStatusSummary(tc.counts, tc.total))
 		})
 	}
 }
@@ -339,6 +416,56 @@ func TestBackupResponseJSONDecoding(t *testing.T) {
 // TestFormatStatus covers the easy-to-regress edge case: error_type is omitempty on the wire,
 // so a collector_error resource routinely decodes with an empty ErrorType, and the STATUS cell
 // must fall through to the bare status rather than leaving a dangling " ()".
+func TestFormatMethod(t *testing.T) {
+	testCases := []struct {
+		name     string
+		resource backupResource
+		expected string
+	}{
+		{
+			name:     "Velero's own name is carried through verbatim",
+			resource: backupResource{Operator: "velero", Stream: "volume", Method: "PodVolumeBackup"},
+			expected: "PodVolumeBackup",
+		},
+		{
+			name:     "acronyms are not reshaped",
+			resource: backupResource{Operator: "velero", Stream: "volume", Method: "CSISnapshot"},
+			expected: "CSISnapshot",
+		},
+		{
+			name:     "CNPG's logical backup is taken by a CronJob",
+			resource: backupResource{Operator: "cnpg", Stream: "logical"},
+			expected: "CronJob",
+		},
+		{
+			name:     "CNPG's wal archive is taken by barman-cloud",
+			resource: backupResource{Operator: "cnpg", Stream: "wal"},
+			expected: "Barman",
+		},
+		{
+			name:     "a reported method wins over the derived one",
+			resource: backupResource{Operator: "cnpg", Stream: "logical", Method: "SomethingElse"},
+			expected: "SomethingElse",
+		},
+		{
+			name:     "an unrecognized CNPG stream has no method to name",
+			resource: backupResource{Operator: "cnpg", Stream: "something_new"},
+			expected: "-",
+		},
+		{
+			name:     "another operator's stream is not given a CNPG mechanism",
+			resource: backupResource{Operator: "mongodb", Stream: "logical"},
+			expected: "-",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, formatMethod(tc.resource))
+		})
+	}
+}
+
 func TestFormatStatus(t *testing.T) {
 	testCases := []struct {
 		name     string
@@ -419,12 +546,19 @@ func TestAnyMethod(t *testing.T) {
 			expected:  false,
 		},
 		{
-			name: "all resources have an empty Method",
+			name: "all resources have an empty Method and no mechanism to derive",
 			resources: []backupResource{
 				{Namespace: "backup", ResourceName: "app-a"},
 				{Namespace: "backup", ResourceName: "app-b"},
 			},
 			expected: false,
+		},
+		{
+			name: "a CNPG row's mechanism counts, though it reports no Method",
+			resources: []backupResource{
+				{Namespace: "backup", ResourceName: "app-a", Operator: "cnpg", Stream: "wal"},
+			},
+			expected: true,
 		},
 		{
 			name: "one resource has a non-empty Method",
@@ -459,7 +593,7 @@ func TestRenderResourceTable(t *testing.T) {
 
 	t.Run("omits the METHOD header when no resource carries a method", func(t *testing.T) {
 		resources := []backupResource{
-			{Namespace: "backup", ResourceName: "app-a", Operator: "cnpg", Stream: "logical", Status: backupStatusHealthy},
+			{Namespace: "backup", ResourceName: "app-a", Operator: "mongodb", Stream: "logical", Status: backupStatusHealthy},
 		}
 		out := renderResourceTable(resources, map[string]*time.Time{}, now)
 		assert.NotContains(t, out, "METHOD")
@@ -631,21 +765,61 @@ func TestFindBackupExporterService(t *testing.T) {
 		assert.Equal(t, "backup-exporter", svc.Name)
 	})
 
-	t.Run("two matching services in different namespaces returns an error naming both", func(t *testing.T) {
-		serviceInBackupNamespace := &coreV1.Service{
-			ObjectMeta: metaV1.ObjectMeta{
-				Name:      "backup-exporter",
-				Namespace: "backup",
-				Labels:    map[string]string{backupExporterLabelKey: backupExporterLabelValue},
-			},
-		}
-		clientset := fake.NewSimpleClientset(unlabeledService, backupExporterServiceFixture(), serviceInBackupNamespace)
+	t.Run("the default namespace wins over a match elsewhere", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset(
+			unlabeledService,
+			backupExporterServiceFixture(),
+			labeledServiceIn("backup"),
+		)
+
+		svc, err := findBackupExporterService(context.Background(), clientset)
+		require.NoError(t, err)
+		assert.Equal(t, backupExporterDefaultNamespace, svc.Namespace,
+			"a second exporter elsewhere must not make the default-namespace one ambiguous")
+	})
+
+	t.Run("a single service outside the default namespace is found by the fallback", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset(unlabeledService, labeledServiceIn("backup"))
+
+		svc, err := findBackupExporterService(context.Background(), clientset)
+		require.NoError(t, err)
+		assert.Equal(t, "backup", svc.Namespace)
+	})
+
+	t.Run("the fallback runs when the default namespace is refused", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset(labeledServiceIn("backup"))
+		clientset.PrependReactor("list", "services", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			if action.GetNamespace() == backupExporterDefaultNamespace {
+				return true, nil, apiErrors.NewForbidden(coreV1.Resource("services"), "", errors.New("no namespaced access"))
+			}
+
+			return false, nil, nil
+		})
+
+		svc, err := findBackupExporterService(context.Background(), clientset)
+		require.NoError(t, err)
+		assert.Equal(t, "backup", svc.Namespace)
+	})
+
+	t.Run("two matching services, neither in the default namespace, returns an error naming both", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset(unlabeledService, labeledServiceIn("backup"), labeledServiceIn("velero"))
 
 		_, err := findBackupExporterService(context.Background(), clientset)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "monitoring")
-		assert.Contains(t, err.Error(), "backup")
+		assert.Contains(t, err.Error(), "backup/backup-exporter")
+		assert.Contains(t, err.Error(), "velero/backup-exporter")
 	})
+}
+
+// labeledServiceIn returns a Service carrying backup-exporter's chart label in namespace.
+func labeledServiceIn(namespace string) *coreV1.Service {
+	return &coreV1.Service{
+		ObjectMeta: metaV1.ObjectMeta{
+			Name:      "backup-exporter",
+			Namespace: namespace,
+			Labels:    map[string]string{backupExporterLabelKey: backupExporterLabelValue},
+		},
+	}
 }
 
 // readyPodFixture returns a Pod carrying podLabels, Running with a Ready=True condition - the

--- a/pkg/core/backup_status_test.go
+++ b/pkg/core/backup_status_test.go
@@ -1,0 +1,960 @@
+// Copyright 2026 Obmondo
+// SPDX-License-Identifier: AGPL3
+
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	coreV1 "k8s.io/api/core/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes/fake"
+	restclient "k8s.io/client-go/rest"
+)
+
+func floatPtr(f float64) *float64                { return &f }
+func timePtr(t time.Time) *time.Time             { return &t }
+func durationPtr(d time.Duration) *time.Duration { return &d }
+
+func TestAdjustedAge(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	collectedAt := now.Add(-10 * time.Minute)
+
+	testCases := []struct {
+		name        string
+		ageSeconds  *float64
+		collectedAt *time.Time
+		expected    *time.Duration
+	}{
+		{
+			name:        "nil age seconds returns nil (no series published)",
+			ageSeconds:  nil,
+			collectedAt: timePtr(collectedAt),
+			expected:    nil,
+		},
+		{
+			name:        "nil collected_at returns nil (no reference point to adjust from)",
+			ageSeconds:  floatPtr(3600),
+			collectedAt: nil,
+			expected:    nil,
+		},
+		{
+			name:        "normal case adds elapsed time since collection",
+			ageSeconds:  floatPtr(3600),       // 1h old as of collection
+			collectedAt: timePtr(collectedAt), // collected 10m ago
+			expected:    durationPtr(70 * time.Minute),
+		},
+		{
+			name:        "zero age (no-backup sentinel) still gets adjusted",
+			ageSeconds:  floatPtr(0),
+			collectedAt: timePtr(collectedAt),
+			expected:    durationPtr(10 * time.Minute),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := adjustedAge(tc.ageSeconds, tc.collectedAt, now)
+			if tc.expected == nil {
+				assert.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			assert.Equal(t, *tc.expected, *got)
+		})
+	}
+}
+
+func TestFormatLatestAge(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	collectedAt := now.Add(-10 * time.Minute)
+
+	testCases := []struct {
+		name        string
+		resource    backupResource
+		collectedAt *time.Time
+		expected    string
+	}{
+		{
+			name:        "nil age renders as -",
+			resource:    backupResource{LatestBackupAgeSeconds: nil},
+			collectedAt: timePtr(collectedAt),
+			expected:    "-",
+		},
+		{
+			name:        "zero age renders as none (no_backup sentinel)",
+			resource:    backupResource{LatestBackupAgeSeconds: floatPtr(0)},
+			collectedAt: timePtr(collectedAt),
+			expected:    "none",
+		},
+		{
+			name:        "normal age is humanized and adjusted for elapsed collection time",
+			resource:    backupResource{LatestBackupAgeSeconds: floatPtr(3 * 3600)},
+			collectedAt: timePtr(collectedAt),
+			expected:    "3h10m", // 3h at collection + 10m elapsed since = 3h10m
+		},
+		{
+			name:        "non-nil age but nil collected_at renders as - (can't safely adjust)",
+			resource:    backupResource{LatestBackupAgeSeconds: floatPtr(3600)},
+			collectedAt: nil,
+			expected:    "-",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, formatLatestAge(tc.resource, tc.collectedAt, now))
+		})
+	}
+}
+
+// TestFormatCollectorLine covers contract subtlety: a collector that has never completed a
+// run (nil CollectedAt) must be surfaced explicitly, not rendered as a stale or empty age.
+func TestFormatCollectorHeader(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+
+	testCases := []struct {
+		name       string
+		collectors []backupCollector
+		expected   string
+	}{
+		{
+			name:       "no collectors reported",
+			collectors: nil,
+			expected:   "no collectors reported",
+		},
+		{
+			name: "single collector",
+			collectors: []backupCollector{
+				{Operator: "cnpg", CollectedAt: timePtr(now.Add(-4 * time.Minute))},
+			},
+			expected: "collected 4m ago: cnpg",
+		},
+		{
+			name: "collectors sharing an age condense to one age",
+			collectors: []backupCollector{
+				{Operator: "cnpg", CollectedAt: timePtr(now.Add(-87 * time.Minute))},
+				{Operator: "velero", CollectedAt: timePtr(now.Add(-87 * time.Minute))},
+			},
+			expected: "collected 87m ago: cnpg | velero",
+		},
+		{
+			name: "differing ages are reported per operator",
+			collectors: []backupCollector{
+				{Operator: "cnpg", CollectedAt: timePtr(now.Add(-87 * time.Minute))},
+				{Operator: "velero", CollectedAt: timePtr(now.Add(-5 * time.Minute))},
+			},
+			expected: "collected: cnpg 87m ago | velero 5m ago",
+		},
+		{
+			name: "a collector that never ran is named beside one that has",
+			collectors: []backupCollector{
+				{Operator: "cnpg", CollectedAt: timePtr(now.Add(-5 * time.Minute))},
+				{Operator: "velero", CollectedAt: nil},
+			},
+			expected: "collected: cnpg 5m ago | velero never",
+		},
+		{
+			name: "no collector has ever completed a run",
+			collectors: []backupCollector{
+				{Operator: "cnpg", CollectedAt: nil},
+				{Operator: "velero", CollectedAt: nil},
+			},
+			expected: "no completed collection run yet: cnpg | velero",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, formatCollectorHeader(tc.collectors, now))
+		})
+	}
+}
+
+func TestCountByStatus(t *testing.T) {
+	resources := []backupResource{
+		{Status: backupStatusHealthy},
+		{Status: backupStatusHealthy},
+		{Status: backupStatusExceedsRPO},
+		{Status: backupStatusNoBackup},
+		{Status: backupStatusNoBackup},
+		{Status: backupStatusNoBackup},
+	}
+
+	counts := countByStatus(resources)
+
+	assert.Equal(t, map[string]int{
+		backupStatusHealthy:    2,
+		backupStatusExceedsRPO: 1,
+		backupStatusNoBackup:   3,
+	}, counts)
+}
+
+func TestFormatStatusSummary(t *testing.T) {
+	testCases := []struct {
+		name     string
+		counts   map[string]int
+		expected string
+	}{
+		{
+			name:     "no resources",
+			counts:   map[string]int{},
+			expected: "no resources reported",
+		},
+		{
+			name: "known statuses render in canonical order regardless of map order",
+			counts: map[string]int{
+				backupStatusNoBackup:   2,
+				backupStatusHealthy:    12,
+				backupStatusExceedsRPO: 1,
+			},
+			expected: "12 healthy, 1 exceeds_rpo, 2 no_backup",
+		},
+		{
+			name: "all five known statuses",
+			counts: map[string]int{
+				backupStatusHealthy:        1,
+				backupStatusExceedsRPO:     1,
+				backupStatusNoBackup:       1,
+				backupStatusCollectorError: 1,
+				backupStatusUnknown:        1,
+			},
+			expected: "1 healthy, 1 exceeds_rpo, 1 no_backup, 1 collector_error, 1 unknown",
+		},
+		{
+			name: "unrecognized status is appended sorted, not dropped",
+			counts: map[string]int{
+				backupStatusHealthy: 1,
+				"weird_status":      1,
+				"another_status":    1,
+			},
+			expected: "1 healthy, 1 another_status, 1 weird_status",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, formatStatusSummary(tc.counts))
+		})
+	}
+}
+
+// TestBackupResponseJSONDecoding decodes a representative GET /api/v1/backups fixture,
+// exercising the contract subtleties a naive decode would miss: a collector that has never
+// run (null collected_at), the no-backup sentinel (age exactly 0, distinct from a genuinely
+// absent age), a collector_error resource with its error_type, and an operator_errors entry.
+func TestBackupResponseJSONDecoding(t *testing.T) {
+	const fixture = `{
+  "collectors": [
+    { "operator": "cnpg", "collected_at": "2026-07-16T08:00:00Z" },
+    { "operator": "velero", "collected_at": null }
+  ],
+  "resources": [
+    {
+      "operator": "cnpg",
+      "stream": "logical",
+      "namespace": "demo",
+      "resource_name": "demo-db",
+      "resource_type": "cnpg_cluster",
+      "latest_backup_age_seconds": 3600,
+      "oldest_backup_age_seconds": 604800,
+      "max_interval_seconds": 601200,
+      "status": "healthy"
+    },
+    {
+      "operator": "velero",
+      "stream": "volume",
+      "namespace": "demo",
+      "resource_name": "demo-app",
+      "resource_type": "pvc",
+      "method": "CSISnapshot",
+      "latest_backup_age_seconds": 0,
+      "oldest_backup_age_seconds": null,
+      "max_interval_seconds": null,
+      "status": "no_backup"
+    },
+    {
+      "operator": "cnpg",
+      "stream": "wal",
+      "namespace": "demo",
+      "resource_name": "demo-db",
+      "resource_type": "cnpg_cluster",
+      "latest_backup_age_seconds": null,
+      "oldest_backup_age_seconds": null,
+      "max_interval_seconds": null,
+      "status": "collector_error",
+      "error_type": "archive_command_failed"
+    }
+  ],
+  "operator_errors": [
+    { "operator": "velero", "type": "s3_list_failed" }
+  ]
+}`
+
+	var response backupResponse
+	err := json.Unmarshal([]byte(fixture), &response)
+	require.NoError(t, err)
+
+	require.Len(t, response.Collectors, 2)
+	assert.Equal(t, "cnpg", response.Collectors[0].Operator)
+	require.NotNil(t, response.Collectors[0].CollectedAt)
+	assert.True(t, response.Collectors[0].CollectedAt.Equal(time.Date(2026, 7, 16, 8, 0, 0, 0, time.UTC)))
+	assert.Equal(t, "velero", response.Collectors[1].Operator)
+	assert.Nil(t, response.Collectors[1].CollectedAt, "an operator that never ran must decode to a nil timestamp, not be omitted")
+
+	require.Len(t, response.Resources, 3)
+
+	healthy := response.Resources[0]
+	require.NotNil(t, healthy.LatestBackupAgeSeconds)
+	assert.InDelta(t, 3600, *healthy.LatestBackupAgeSeconds, 0)
+	assert.Equal(t, backupStatusHealthy, healthy.Status)
+
+	noBackup := response.Resources[1]
+	require.NotNil(t, noBackup.LatestBackupAgeSeconds, "a reported zero age must decode as a pointer to 0, not nil")
+	assert.InDelta(t, 0, *noBackup.LatestBackupAgeSeconds, 0)
+	assert.Nil(t, noBackup.OldestBackupAgeSeconds, "a genuinely absent age must decode as nil, not 0")
+	assert.Equal(t, "CSISnapshot", noBackup.Method)
+
+	collectorErr := response.Resources[2]
+	assert.Nil(t, collectorErr.LatestBackupAgeSeconds)
+	assert.Equal(t, backupStatusCollectorError, collectorErr.Status)
+	assert.Equal(t, "archive_command_failed", collectorErr.ErrorType)
+
+	require.Len(t, response.OperatorErrors, 1)
+	assert.Equal(t, "velero", response.OperatorErrors[0].Operator)
+	assert.Equal(t, "s3_list_failed", response.OperatorErrors[0].Type)
+}
+
+// TestFormatStatus covers the easy-to-regress edge case: error_type is omitempty on the wire,
+// so a collector_error resource routinely decodes with an empty ErrorType, and the STATUS cell
+// must fall through to the bare status rather than leaving a dangling " ()".
+func TestFormatStatus(t *testing.T) {
+	testCases := []struct {
+		name     string
+		resource backupResource
+		expected string
+	}{
+		{
+			name:     "plain status passes through unchanged",
+			resource: backupResource{Status: backupStatusHealthy},
+			expected: "healthy",
+		},
+		{
+			name:     "collector_error with a non-empty error_type folds it into the cell",
+			resource: backupResource{Status: backupStatusCollectorError, ErrorType: "archive_command_failed"},
+			expected: "collector_error (archive_command_failed)",
+		},
+		{
+			name:     "collector_error with an empty error_type falls through to the bare status",
+			resource: backupResource{Status: backupStatusCollectorError, ErrorType: ""},
+			expected: "collector_error",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, formatStatus(tc.resource))
+		})
+	}
+}
+
+// TestSortResources exercises the full 5-key cascading comparator documented on sortResources
+// as "the display contract". Each pair of rows below ties on every key up to (but not
+// including) the one it's meant to test, so the first two keys (Namespace, ResourceName) alone
+// can never produce the asserted order by accident - only the deeper key can. ResourceType
+// carries a "tiebreak" tag identifying each row post-sort; sortResources never reads that
+// field, so it can't influence the outcome it's used to verify.
+func TestSortResources(t *testing.T) {
+	resources := []backupResource{
+		// Ties on Namespace+ResourceName+Operator+Stream; only Method differs.
+		{Namespace: "backup", ResourceName: "app-c", Operator: "velero", Stream: "volume", Method: "Restic", ResourceType: "method-tiebreak-2"},
+		{Namespace: "backup", ResourceName: "app-c", Operator: "velero", Stream: "volume", Method: "CSISnapshot", ResourceType: "method-tiebreak-1"},
+
+		// Ties on Namespace+ResourceName+Operator; only Stream differs.
+		{Namespace: "backup", ResourceName: "app-b", Operator: "cnpg", Stream: "wal", ResourceType: "stream-tiebreak-2"},
+		{Namespace: "backup", ResourceName: "app-b", Operator: "cnpg", Stream: "logical", ResourceType: "stream-tiebreak-1"},
+
+		// Ties on Namespace+ResourceName; only Operator differs.
+		{Namespace: "backup", ResourceName: "app-a", Operator: "velero", ResourceType: "operator-tiebreak-2"},
+		{Namespace: "backup", ResourceName: "app-a", Operator: "cnpg", ResourceType: "operator-tiebreak-1"},
+	}
+
+	sortResources(resources)
+
+	got := make([]string, len(resources))
+	for i, r := range resources {
+		got[i] = r.ResourceType
+	}
+
+	assert.Equal(t, []string{
+		"operator-tiebreak-1", // app-a/cnpg before app-a/velero
+		"operator-tiebreak-2",
+		"stream-tiebreak-1", // app-b/cnpg/logical before app-b/cnpg/wal
+		"stream-tiebreak-2",
+		"method-tiebreak-1", // app-c/velero/volume/CSISnapshot before .../Restic
+		"method-tiebreak-2",
+	}, got)
+}
+
+func TestAnyMethod(t *testing.T) {
+	testCases := []struct {
+		name      string
+		resources []backupResource
+		expected  bool
+	}{
+		{
+			name:      "empty slice",
+			resources: []backupResource{},
+			expected:  false,
+		},
+		{
+			name: "all resources have an empty Method",
+			resources: []backupResource{
+				{Namespace: "backup", ResourceName: "app-a"},
+				{Namespace: "backup", ResourceName: "app-b"},
+			},
+			expected: false,
+		},
+		{
+			name: "one resource has a non-empty Method",
+			resources: []backupResource{
+				{Namespace: "backup", ResourceName: "app-a"},
+				{Namespace: "backup", ResourceName: "app-b", Method: "CSISnapshot"},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, anyMethod(tc.resources))
+		})
+	}
+}
+
+// TestRenderResourceTable intentionally uses substring assertions rather than an exact-string
+// or golden-file match: tabwriter's column padding makes exact matches brittle, and no other
+// table-render function in this repo has an exact-match test either.
+func TestRenderResourceTable(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+
+	t.Run("includes the METHOD header when a resource carries a method", func(t *testing.T) {
+		resources := []backupResource{
+			{Namespace: "backup", ResourceName: "app-a", Operator: "velero", Stream: "volume", Method: "CSISnapshot", Status: backupStatusHealthy},
+		}
+		out := renderResourceTable(resources, map[string]*time.Time{}, now)
+		assert.Contains(t, out, "METHOD")
+	})
+
+	t.Run("omits the METHOD header when no resource carries a method", func(t *testing.T) {
+		resources := []backupResource{
+			{Namespace: "backup", ResourceName: "app-a", Operator: "cnpg", Stream: "logical", Status: backupStatusHealthy},
+		}
+		out := renderResourceTable(resources, map[string]*time.Time{}, now)
+		assert.NotContains(t, out, "METHOD")
+	})
+
+	t.Run("renders resource rows in sortResources order", func(t *testing.T) {
+		resources := []backupResource{
+			{Namespace: "backup", ResourceName: "zzz-last", Operator: "cnpg", Stream: "logical", Status: backupStatusHealthy},
+			{Namespace: "backup", ResourceName: "aaa-first", Operator: "cnpg", Stream: "logical", Status: backupStatusHealthy},
+			{Namespace: "backup", ResourceName: "mmm-middle", Operator: "cnpg", Stream: "logical", Status: backupStatusHealthy},
+		}
+		out := renderResourceTable(resources, map[string]*time.Time{}, now)
+
+		firstIdx := strings.Index(out, "aaa-first")
+		middleIdx := strings.Index(out, "mmm-middle")
+		lastIdx := strings.Index(out, "zzz-last")
+		require.NotEqual(t, -1, firstIdx, "aaa-first must appear in the rendered table")
+		require.NotEqual(t, -1, middleIdx, "mmm-middle must appear in the rendered table")
+		require.NotEqual(t, -1, lastIdx, "zzz-last must appear in the rendered table")
+
+		assert.Less(t, firstIdx, middleIdx, "aaa-first must render before mmm-middle")
+		assert.Less(t, middleIdx, lastIdx, "mmm-middle must render before zzz-last")
+	})
+
+	t.Run("one row per backup stream, under a single header row", func(t *testing.T) {
+		resources := []backupResource{
+			{Namespace: "demo", ResourceName: "demo-pgsql", ResourceType: "cnpg_cluster", Operator: "cnpg", Stream: "logical", Status: backupStatusNoBackup},
+			{Namespace: "demo", ResourceName: "demo-pgsql", ResourceType: "cnpg_cluster", Operator: "cnpg", Stream: "wal", Status: backupStatusHealthy},
+			{Namespace: "demo", ResourceName: "demo-uploads", ResourceType: "pvc", Operator: "velero", Stream: "volume", Status: backupStatusHealthy},
+		}
+
+		out := renderResourceTable(resources, map[string]*time.Time{}, now)
+
+		lines := strings.Split(out, "\n")
+		require.Len(t, lines, len(resources)+1, "one header row plus one row per stream")
+		assert.True(t, strings.HasPrefix(lines[0], "NAMESPACE"), "the header row comes first")
+	})
+
+	t.Run("columns line up across rows of differing width", func(t *testing.T) {
+		resources := []backupResource{
+			{Namespace: "demo", ResourceName: "a-much-longer-name", ResourceType: "pvc", Operator: "velero", Stream: "volume", Status: backupStatusHealthy},
+			{Namespace: "demo", ResourceName: "short", ResourceType: "pvc", Operator: "velero", Stream: "volume", Status: backupStatusHealthy},
+		}
+
+		out := renderResourceTable(resources, map[string]*time.Time{}, now)
+
+		lines := strings.Split(out, "\n")
+		require.Len(t, lines, 3)
+		assert.Equal(t, strings.Index(lines[1], "pvc"), strings.Index(lines[2], "pvc"),
+			"the TYPE column starts at one offset for every row")
+	})
+}
+
+// TestRenderBackupStatus, like TestRenderResourceTable, sticks to substring/position assertions
+// rather than an exact-string match.
+func TestRenderBackupStatus(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+
+	t.Run("collector freshness is the first line, in Collectors order", func(t *testing.T) {
+		resp := backupResponse{
+			Collectors: []backupCollector{
+				{Operator: "velero", CollectedAt: timePtr(now.Add(-5 * time.Minute))},
+				{Operator: "cnpg", CollectedAt: nil},
+			},
+			Resources: []backupResource{
+				{Namespace: "backup", ResourceName: "app-a", Operator: "velero", Stream: "volume", Status: backupStatusHealthy},
+			},
+		}
+
+		out := renderBackupStatus(resp, now)
+
+		lines := strings.Split(out, "\n")
+		require.NotEmpty(t, lines)
+		assert.Equal(t, "collected: velero 5m ago | cnpg never", lines[0])
+	})
+
+	t.Run("Operator errors section present when OperatorErrors is non-empty", func(t *testing.T) {
+		resp := backupResponse{
+			OperatorErrors: []backupOperatorError{
+				{Operator: "velero", Type: "s3_list_failed"},
+			},
+		}
+
+		out := renderBackupStatus(resp, now)
+
+		assert.Contains(t, out, "Operator errors:")
+		assert.Contains(t, out, "velero: s3_list_failed")
+	})
+
+	t.Run("Operator errors section absent when OperatorErrors is empty", func(t *testing.T) {
+		resp := backupResponse{}
+
+		out := renderBackupStatus(resp, now)
+
+		assert.NotContains(t, out, "Operator errors:")
+	})
+
+	t.Run("status summary line is the last non-empty line", func(t *testing.T) {
+		resp := backupResponse{
+			Collectors: []backupCollector{
+				{Operator: "cnpg", CollectedAt: timePtr(now.Add(-5 * time.Minute))},
+			},
+			Resources: []backupResource{
+				{Namespace: "backup", ResourceName: "app-a", Operator: "cnpg", Stream: "logical", Status: backupStatusHealthy},
+			},
+		}
+
+		out := renderBackupStatus(resp, now)
+
+		lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+		require.NotEmpty(t, lines)
+
+		expectedSummary := formatStatusSummary(countByStatus(resp.Resources))
+		assert.Equal(t, expectedSummary, lines[len(lines)-1])
+	})
+
+	t.Run("no resource table when Resources is empty", func(t *testing.T) {
+		// renderBackupStatus skips calling renderResourceTable entirely when
+		// len(resp.Resources) == 0, rather than rendering a headers-only table.
+		resp := backupResponse{
+			Collectors: []backupCollector{
+				{Operator: "cnpg", CollectedAt: timePtr(now.Add(-5 * time.Minute))},
+			},
+		}
+
+		out := renderBackupStatus(resp, now)
+
+		assert.NotContains(t, out, "NAMESPACE", "no table header should render when there are zero resources")
+		assert.Contains(t, out, "no resources reported")
+	})
+}
+
+// backupExporterServiceFixture returns a Service carrying the label backup-exporter's Helm
+// chart stamps on its Service, in namespace "monitoring".
+func backupExporterServiceFixture() *coreV1.Service {
+	return &coreV1.Service{
+		ObjectMeta: metaV1.ObjectMeta{
+			Name:      "backup-exporter",
+			Namespace: "monitoring",
+			Labels:    map[string]string{backupExporterLabelKey: backupExporterLabelValue},
+		},
+	}
+}
+
+func TestFindBackupExporterService(t *testing.T) {
+	// Seeded into every case below to confirm the label selector actually filters, rather
+	// than findBackupExporterService just returning whatever Services happen to exist.
+	unlabeledService := &coreV1.Service{
+		ObjectMeta: metaV1.ObjectMeta{
+			Name:      "some-other-service",
+			Namespace: "monitoring",
+		},
+	}
+
+	t.Run("zero matching services returns an error", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset(unlabeledService)
+
+		_, err := findBackupExporterService(context.Background(), clientset)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no backup-exporter service found")
+	})
+
+	t.Run("exactly one matching service returns it", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset(unlabeledService, backupExporterServiceFixture())
+
+		svc, err := findBackupExporterService(context.Background(), clientset)
+		require.NoError(t, err)
+		assert.Equal(t, "monitoring", svc.Namespace)
+		assert.Equal(t, "backup-exporter", svc.Name)
+	})
+
+	t.Run("two matching services in different namespaces returns an error naming both", func(t *testing.T) {
+		serviceInBackupNamespace := &coreV1.Service{
+			ObjectMeta: metaV1.ObjectMeta{
+				Name:      "backup-exporter",
+				Namespace: "backup",
+				Labels:    map[string]string{backupExporterLabelKey: backupExporterLabelValue},
+			},
+		}
+		clientset := fake.NewSimpleClientset(unlabeledService, backupExporterServiceFixture(), serviceInBackupNamespace)
+
+		_, err := findBackupExporterService(context.Background(), clientset)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "monitoring")
+		assert.Contains(t, err.Error(), "backup")
+	})
+}
+
+// readyPodFixture returns a Pod carrying podLabels, Running with a Ready=True condition - the
+// bar findReadyPod requires - in namespace "monitoring" (matching backupExporterServiceFixture).
+// Tests mutate the returned pod's Status to build not-ready variants.
+func readyPodFixture(name string, podLabels map[string]string) *coreV1.Pod {
+	return &coreV1.Pod{
+		ObjectMeta: metaV1.ObjectMeta{
+			Name:      name,
+			Namespace: "monitoring",
+			Labels:    podLabels,
+		},
+		Status: coreV1.PodStatus{
+			Phase: coreV1.PodRunning,
+			Conditions: []coreV1.PodCondition{
+				{Type: coreV1.PodReady, Status: coreV1.ConditionTrue},
+			},
+		},
+	}
+}
+
+// TestFindReadyPod exercises the selector as a real filter (a mismatched-label pod is seeded
+// alongside matching ones, same rationale as TestFindBackupExporterService's unlabeledService)
+// and the Running+Ready bar itself, using the fake clientset. It never touches
+// fetchViaPortForward/newPortForwardDialer: those call clientset.CoreV1().RESTClient(), which
+// the fake clientset returns as a typed-nil *rest.RESTClient - calling into it panics, so the
+// port-forward stream itself is deliberately left untested here.
+func TestFindReadyPod(t *testing.T) {
+	selector := map[string]string{backupExporterLabelKey: backupExporterLabelValue}
+
+	t.Run("returns the first Running+Ready pod, skipping not-ready and mismatched-label pods", func(t *testing.T) {
+		notReady := readyPodFixture("backup-exporter-not-ready", selector)
+		notReady.Status.Conditions[0].Status = coreV1.ConditionFalse
+
+		otherLabels := readyPodFixture("some-other-pod", map[string]string{"app": "unrelated"})
+
+		ready := readyPodFixture("backup-exporter-ready", selector)
+
+		clientset := fake.NewSimpleClientset(notReady, otherLabels, ready)
+
+		pod, err := findReadyPod(context.Background(), clientset, "monitoring", "backup-exporter", selector)
+		require.NoError(t, err)
+		assert.Equal(t, "backup-exporter-ready", pod.Name)
+	})
+
+	t.Run("a matching pod that's never Running is not selected", func(t *testing.T) {
+		pending := readyPodFixture("backup-exporter-pending", selector)
+		pending.Status.Phase = coreV1.PodPending
+
+		clientset := fake.NewSimpleClientset(pending)
+
+		_, err := findReadyPod(context.Background(), clientset, "monitoring", "backup-exporter", selector)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no ready pod behind service monitoring/backup-exporter")
+	})
+
+	t.Run("no pods match the selector errors naming the service, not a generic empty list", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+
+		_, err := findReadyPod(context.Background(), clientset, "monitoring", "backup-exporter", selector)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "monitoring/backup-exporter")
+	})
+
+	t.Run("an empty selector errors without listing pods", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+
+		_, err := findReadyPod(context.Background(), clientset, "monitoring", "backup-exporter", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no pod selector")
+	})
+}
+
+// TestPodReady covers the two-part contract (Running phase AND a Ready=True condition)
+// independently: neither one alone is enough.
+func TestPodReady(t *testing.T) {
+	testCases := []struct {
+		name     string
+		pod      *coreV1.Pod
+		expected bool
+	}{
+		{
+			name: "running and ready",
+			pod: &coreV1.Pod{Status: coreV1.PodStatus{
+				Phase:      coreV1.PodRunning,
+				Conditions: []coreV1.PodCondition{{Type: coreV1.PodReady, Status: coreV1.ConditionTrue}},
+			}},
+			expected: true,
+		},
+		{
+			name: "running but the Ready condition is False",
+			pod: &coreV1.Pod{Status: coreV1.PodStatus{
+				Phase:      coreV1.PodRunning,
+				Conditions: []coreV1.PodCondition{{Type: coreV1.PodReady, Status: coreV1.ConditionFalse}},
+			}},
+			expected: false,
+		},
+		{
+			name: "running but no PodReady condition was ever reported",
+			pod: &coreV1.Pod{Status: coreV1.PodStatus{
+				Phase:      coreV1.PodRunning,
+				Conditions: []coreV1.PodCondition{{Type: coreV1.PodInitialized, Status: coreV1.ConditionTrue}},
+			}},
+			expected: false,
+		},
+		{
+			name: "marked ready but not in the Running phase",
+			pod: &coreV1.Pod{Status: coreV1.PodStatus{
+				Phase:      coreV1.PodPending,
+				Conditions: []coreV1.PodCondition{{Type: coreV1.PodReady, Status: coreV1.ConditionTrue}},
+			}},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, podReady(tc.pod))
+		})
+	}
+}
+
+// TestBackupExporterServicePort covers the "which Service port" decision: named "http", or the
+// Service's only port regardless of its name.
+func TestBackupExporterServicePort(t *testing.T) {
+	t.Run("a single port is used regardless of its name", func(t *testing.T) {
+		svc := &coreV1.Service{Spec: coreV1.ServiceSpec{
+			Ports: []coreV1.ServicePort{{Name: "metrics", Port: 9090}},
+		}}
+
+		port, err := backupExporterServicePort(svc)
+		require.NoError(t, err)
+		assert.Equal(t, int32(9090), port.Port)
+	})
+
+	t.Run("multiple ports: the one named http is picked", func(t *testing.T) {
+		svc := &coreV1.Service{Spec: coreV1.ServiceSpec{
+			Ports: []coreV1.ServicePort{
+				{Name: "metrics", Port: 9090},
+				{Name: "http", Port: 8080},
+			},
+		}}
+
+		port, err := backupExporterServicePort(svc)
+		require.NoError(t, err)
+		assert.Equal(t, int32(8080), port.Port)
+	})
+
+	t.Run("multiple ports, none named http, errors naming the service", func(t *testing.T) {
+		svc := &coreV1.Service{
+			ObjectMeta: metaV1.ObjectMeta{Name: "backup-exporter", Namespace: "monitoring"},
+			Spec: coreV1.ServiceSpec{
+				Ports: []coreV1.ServicePort{
+					{Name: "metrics", Port: 9090},
+					{Name: "admin", Port: 9091},
+				},
+			},
+		}
+
+		_, err := backupExporterServicePort(svc)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "monitoring/backup-exporter")
+	})
+}
+
+// TestResolveTargetPort covers the "Service port -> container port" translation: numeric
+// TargetPort, named TargetPort (found and missing), and an omitted TargetPort defaulting to
+// Port - the same cases k8s.io/kubectl/pkg/util's target-port lookup handles.
+func TestResolveTargetPort(t *testing.T) {
+	pod := &coreV1.Pod{
+		ObjectMeta: metaV1.ObjectMeta{Name: "backup-exporter-abc", Namespace: "monitoring"},
+		Spec: coreV1.PodSpec{
+			Containers: []coreV1.Container{
+				{Ports: []coreV1.ContainerPort{{Name: "http", ContainerPort: 8080}}},
+			},
+		},
+	}
+
+	t.Run("numeric TargetPort is used directly", func(t *testing.T) {
+		svc := &coreV1.Service{Spec: coreV1.ServiceSpec{
+			Ports: []coreV1.ServicePort{{Name: "http", Port: 80, TargetPort: intstr.FromInt32(8080)}},
+		}}
+
+		port, err := resolveTargetPort(svc, pod)
+		require.NoError(t, err)
+		assert.Equal(t, int32(8080), port)
+	})
+
+	t.Run("named TargetPort resolves against the pod's container ports", func(t *testing.T) {
+		svc := &coreV1.Service{Spec: coreV1.ServiceSpec{
+			Ports: []coreV1.ServicePort{{Name: "http", Port: 80, TargetPort: intstr.FromString("http")}},
+		}}
+
+		port, err := resolveTargetPort(svc, pod)
+		require.NoError(t, err)
+		assert.Equal(t, int32(8080), port)
+	})
+
+	t.Run("named TargetPort missing from the pod's containers errors", func(t *testing.T) {
+		svc := &coreV1.Service{Spec: coreV1.ServiceSpec{
+			Ports: []coreV1.ServicePort{{Name: "http", Port: 80, TargetPort: intstr.FromString("metrics")}},
+		}}
+
+		_, err := resolveTargetPort(svc, pod)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `"metrics"`)
+	})
+
+	t.Run("an omitted TargetPort defaults to the Service's Port", func(t *testing.T) {
+		svc := &coreV1.Service{Spec: coreV1.ServiceSpec{
+			Ports: []coreV1.ServicePort{{Name: "http", Port: 8080}},
+		}}
+
+		port, err := resolveTargetPort(svc, pod)
+		require.NoError(t, err)
+		assert.Equal(t, int32(8080), port)
+	})
+
+	t.Run("no eligible service port errors before looking at the pod at all", func(t *testing.T) {
+		svc := &coreV1.Service{
+			ObjectMeta: metaV1.ObjectMeta{Name: "backup-exporter", Namespace: "monitoring"},
+			Spec: coreV1.ServiceSpec{
+				Ports: []coreV1.ServicePort{
+					{Name: "metrics", Port: 9090},
+					{Name: "admin", Port: 9091},
+				},
+			},
+		}
+
+		_, err := resolveTargetPort(svc, pod)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "none named")
+	})
+}
+
+// TestFetchBackupStatus exercises fetchBackupStatus's own sequencing (find Service -> find
+// ready pod) up to but not including fetchViaPortForward: that needs a real pods/portforward
+// stream and is deliberately left untested here, same reasoning as TestFindReadyPod's doc
+// comment on why the fake clientset can't stand in for it. restConfig is never dereferenced
+// on either path below (fetchViaPortForward is never reached), so an empty one is fine.
+func TestFetchBackupStatus(t *testing.T) {
+	t.Run("service discovery failure short-circuits before looking for a pod", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+
+		_, err := fetchBackupStatus(context.Background(), clientset, &restclient.Config{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no backup-exporter service found")
+	})
+
+	t.Run("no ready pod behind the service short-circuits before resolving a port or forwarding", func(t *testing.T) {
+		svc := &coreV1.Service{
+			ObjectMeta: metaV1.ObjectMeta{
+				Name:      "backup-exporter",
+				Namespace: "monitoring",
+				Labels:    map[string]string{backupExporterLabelKey: backupExporterLabelValue},
+			},
+			Spec: coreV1.ServiceSpec{
+				Selector: map[string]string{backupExporterLabelKey: backupExporterLabelValue},
+				Ports:    []coreV1.ServicePort{{Name: "http", Port: 8080}},
+			},
+		}
+		clientset := fake.NewSimpleClientset(svc)
+
+		_, err := fetchBackupStatus(context.Background(), clientset, &restclient.Config{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no ready pod behind service monitoring/backup-exporter")
+	})
+}
+
+// serverPort extracts the numeric port an httptest.Server is listening on, for
+// getBackupsOverLocalPort's uint16 parameter. httptest.NewServer always binds 127.0.0.1,
+// matching the fixed host getBackupsOverLocalPort itself targets.
+func serverPort(t *testing.T, server *httptest.Server) uint16 {
+	t.Helper()
+	parsedURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	port, err := strconv.ParseUint(parsedURL.Port(), 10, 16)
+	require.NoError(t, err)
+	return uint16(port)
+}
+
+// TestGetBackupsOverLocalPort covers the plain-HTTP half of the port-forward fetch in
+// isolation, via a real (if local) HTTP server - unlike fetchViaPortForward/newPortForwardDialer,
+// nothing here touches client-go's SPDY/WebSocket machinery, so it needs no fake-clientset
+// workaround.
+func TestGetBackupsOverLocalPort(t *testing.T) {
+	t.Run("200 returns the body verbatim", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, backupExporterAPIPath, r.URL.Path)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"collectors":[],"resources":[]}`))
+		}))
+		defer server.Close()
+
+		body, err := getBackupsOverLocalPort(context.Background(), serverPort(t, server))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"collectors":[],"resources":[]}`, string(body))
+	})
+
+	t.Run("non-200 status returns an error including the response body", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte("collector not ready"))
+		}))
+		defer server.Close()
+
+		_, err := getBackupsOverLocalPort(context.Background(), serverPort(t, server))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "503")
+		assert.Contains(t, err.Error(), "collector not ready")
+	})
+}

--- a/pkg/core/upgrade_cluster_kubeone.go
+++ b/pkg/core/upgrade_cluster_kubeone.go
@@ -257,11 +257,21 @@ func getLowestNodeKubeletVersion(ctx context.Context) (string, bool) {
 	return lowestRaw, lowest != nil
 }
 
+// checkMainClusterKubeconfigExists errors clearly when the main cluster's kubeconfig is
+// missing (cluster not yet provisioned), instead of letting callers fail on whatever
+// lower-level error clientcmd produces for a nonexistent file.
+func checkMainClusterKubeconfigExists() error {
+	if _, err := os.Stat(constants.OutputPathMainClusterKubeconfig); err != nil {
+		return fmt.Errorf("main cluster kubeconfig not found: %w", err)
+	}
+	return nil
+}
+
 // getMainClusterClient constructs a Kubernetes client for the main cluster, from the kubeconfig
 // KubeOne generated during cluster provisioning.
 func getMainClusterClient(ctx context.Context) (client.Client, error) {
-	if _, err := os.Stat(constants.OutputPathMainClusterKubeconfig); err != nil {
-		return nil, fmt.Errorf("main cluster kubeconfig not found: %w", err)
+	if err := checkMainClusterKubeconfigExists(); err != nil {
+		return nil, err
 	}
 	return kubernetes.CreateKubernetesClient(ctx, constants.OutputPathMainClusterKubeconfig)
 }

--- a/pkg/utils/kubernetes/kubernetes.go
+++ b/pkg/utils/kubernetes/kubernetes.go
@@ -22,6 +22,8 @@ import (
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	k8sclientset "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	kubeadmConstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	capaV1Beta2 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
@@ -93,6 +95,38 @@ func CreateKubernetesClient(ctx context.Context, kubeconfigPath string) (client.
 
 	err = pingKubernetesClusterFn(ctx, clusterClient)
 	return clusterClient, err
+}
+
+// CreateRESTConfig loads the standard kubectl config rules ($KUBECONFIG, else ~/.kube/config)
+// for the current context. The lower-level counterpart to CreateClientset, for callers that
+// need the raw *rest.Config itself (e.g. to build a pods/portforward dialer).
+func CreateRESTConfig(_ context.Context) (*restclient.Config, error) {
+	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		clientcmd.NewDefaultClientConfigLoadingRules(),
+		&clientcmd.ConfigOverrides{},
+	).ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed loading kubeconfig (KUBECONFIG or ~/.kube/config): %w", err)
+	}
+	return config, nil
+}
+
+// CreateClientset builds a typed client-go Clientset from CreateRESTConfig. Needed alongside
+// CreateKubernetesClient: the controller-runtime client it returns has no equivalent to the
+// typed clientset's pods/portforward subresource call. Returns the k8sclientset.Interface (not
+// the concrete *Clientset) so callers can substitute k8s.io/client-go/kubernetes/fake in
+// tests.
+func CreateClientset(ctx context.Context) (k8sclientset.Interface, error) {
+	config, err := CreateRESTConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	clientset, err := k8sclientset.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed creating kubernetes clientset from kubeconfig: %w", err)
+	}
+	return clientset, nil
 }
 
 // CreateUnstructuredClient creates a Kubernetes client suitable for working with

--- a/pkg/utils/kubernetes/kubernetes_test.go
+++ b/pkg/utils/kubernetes/kubernetes_test.go
@@ -132,6 +132,19 @@ func TestCreateKubernetesClient(t *testing.T) {
 	}
 }
 
+// TestCreateRESTConfig covers the error path: a $KUBECONFIG pointing at a nonexistent file
+// must fail with a clear wrapped error rather than clientcmd's raw one. No t.Parallel() here -
+// it mutates the process-wide KUBECONFIG env var via t.Setenv, which Go's testing package
+// disallows once a test tree has gone parallel.
+func TestCreateRESTConfig(t *testing.T) {
+	kubeconfigPath := filepath.Join(t.TempDir(), "does-not-exist.yaml")
+	t.Setenv("KUBECONFIG", kubeconfigPath)
+
+	_, err := CreateRESTConfig(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed loading kubeconfig")
+}
+
 func TestPingKubernetesCluster(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Report a cluster's CNPG and Velero backup health from backup-exporter's /api/v1/backups: one collector-freshness line, any operator-level collector errors, a plain aligned table of every backup stream (latest age, status), and a status summary. -o json prints the raw response body verbatim.

The command sits in a new top-level backup group and parses no general.yaml/secrets.yaml, connecting with the current kubeconfig the way kubectl does.

The exporter is reached over pods/portforward with client-go, the same subresource kubectl port-forward uses, after discovering the Service by the app.kubernetes.io/name=backup-exporter label across namespaces. The API server's services/proxy subresource cannot be used: an L7 proxy in front of kube-apiserver, such as netbird's ClusterProxy, answers those requests with a 404 while passing every other verb through.

Ages are adjusted by the elapsed time since the operator's collected_at, as the API requires of consumers; a null age renders "-" and the zero no-backup sentinel renders "none" without adjustment. Unhealthy statuses do not affect the exit code; only a failed fetch or decode does.