### PR TITLE
chore(k8s-eol): refresh embedded endoflife.date snapshot

### DIFF
--- a/pkg/config/parser/k8s-eol.json
+++ b/pkg/config/parser/k8s-eol.json
@@ -3,8 +3,8 @@
     "cycle": "1.36",
     "releaseDate": "2026-04-22",
     "eol": "2027-06-28",
-    "latest": "1.36.2",
-    "latestReleaseDate": "2026-06-11",
+    "latest": "1.36.3",
+    "latestReleaseDate": "2026-07-22",
     "lts": false,
     "support": "2027-04-28"
   },
@@ -12,8 +12,8 @@
     "cycle": "1.35",
     "releaseDate": "2025-12-17",
     "eol": "2027-02-28",
-    "latest": "1.35.6",
-    "latestReleaseDate": "2026-06-11",
+    "latest": "1.35.7",
+    "latestReleaseDate": "2026-07-22",
     "lts": false,
     "support": "2026-12-28"
   },
@@ -21,8 +21,8 @@
     "cycle": "1.34",
     "releaseDate": "2025-08-27",
     "eol": "2026-10-27",
-    "latest": "1.34.9",
-    "latestReleaseDate": "2026-06-11",
+    "latest": "1.34.10",
+    "latestReleaseDate": "2026-07-22",
     "lts": false,
     "support": "2026-08-27"
   },
@@ -47,7 +47,7 @@
   {
     "cycle": "1.31",
     "releaseDate": "2024-08-13",
-    "eol": "2025-10-28",
+    "eol": "2025-11-11",
     "latest": "1.31.14",
     "latestReleaseDate": "2025-11-11",
     "lts": false,
@@ -56,7 +56,7 @@
   {
     "cycle": "1.30",
     "releaseDate": "2024-04-17",
-    "eol": "2025-06-28",
+    "eol": "2025-07-15",
     "latest": "1.30.14",
     "latestReleaseDate": "2025-06-17",
     "lts": false,


### PR DESCRIPTION
### What

Regenerate the embedded Kubernetes EOL snapshot `pkg/config/parser/k8s-eol.json` from the live [endoflife.date](https://endoflife.date/api/kubernetes.json) feed (`make fetch-k8s-eol`).

### Why

CI's `check-k8s-eol` job re-fetches the feed and fails when the committed snapshot no longer matches it. The feed has drifted since the snapshot was last taken:

- new patch releases — `1.36.3`, `1.35.7`, `1.34.10` (with July release dates)
- corrected historical EOL dates — `1.31` → `2025-11-11`, `1.30` → `2025-07-15`

So the check now fails on **unrelated** PRs (e.g. #32). This refresh is a data-only change to unblock them.

### Verification

- `make check-k8s-eol` passes against the committed file.
- `go test ./pkg/config/parser/` passes (the parser reads the refreshed JSON).
- `jq` confirms the file is a valid, non-empty array.

Data-only; no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
