### PR TITLE
fix(lint): check fmt.Fprintln returns in renderResourceTable

### DIFF
--- a/pkg/core/backup_status.go
+++ b/pkg/core/backup_status.go
@@ -773,7 +773,10 @@ func renderResourceTable(resources []backupResource, collectedAt map[string]*tim
 	var b strings.Builder
 
 	w := tabwriter.NewWriter(&b, tabwriterMinWidth, tabwriterTabWidth, tabwriterPadding, ' ', 0)
-	fmt.Fprintln(w, strings.Join(headers, "\t"))
+	// Writes to a strings.Builder-backed tabwriter never fail; the Flush
+	// below carries the same note. Discard the error explicitly to satisfy
+	// errcheck.
+	_, _ = fmt.Fprintln(w, strings.Join(headers, "\t"))
 
 	for _, r := range sorted {
 		row := []string{r.Namespace, r.ResourceName, r.ResourceType, r.Stream}
@@ -782,7 +785,7 @@ func renderResourceTable(resources []backupResource, collectedAt map[string]*tim
 		}
 		row = append(row, formatLatestAge(r, collectedAt[r.Operator], now), formatStatus(r))
 
-		fmt.Fprintln(w, strings.Join(row, "\t"))
+		_, _ = fmt.Fprintln(w, strings.Join(row, "\t"))
 	}
 
 	// Flush only fails when the underlying writer does, and a strings.Builder never does.


### PR DESCRIPTION
### What

Check the return values of the two `fmt.Fprintln` calls in `renderResourceTable` (`pkg/core/backup_status.go`), discarding them with `_, _ =`.

### Why

The `golangci-lint` CI job runs with `only-new-issues: false`, so it lints the whole tree — and these two unchecked `fmt.Fprintln` returns (errcheck) fail the job on **every** PR, not just the one that introduced them (they surfaced red on #32, [run](https://github.com/Obmondo/kubeaid-cli/actions/runs/30239884880/job/89896008912)).

Discarding the error explicitly matches the `_ = w.Flush()` line immediately below: the `tabwriter` is backed by a `strings.Builder`, whose writes never fail. No behaviour change.

### Verification

- `golangci-lint run --timeout=10m --config=.golangci.yaml ./...` → **0 issues** (whole repo, exact CI invocation).
- `go build ./...` and `go test ./pkg/core/` pass; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
