### PR TITLE
docs(config): correct how consumers get the form spec

### DIFF
--- a/cmd/kubeaid-core/root/config/schema.go
+++ b/cmd/kubeaid-core/root/config/schema.go
@@ -21,8 +21,10 @@ var SchemaCmd = &cobra.Command{
 secrets.yaml field — path, type, tier, required, default, enum and
 appliesWhen — read-only, no config files or cluster required.
 
-This is what the Obmondo API's add-cluster web form renders from: invoke
-a pinned kubeaid-cli release binary and parse stdout as JSON.`,
+The same spec is committed at pkg/config/schema/formspec.json and is
+generated from the config structs by tools/generators. Consumers vendor
+that file; this command prints it for a specific released binary, so a
+refresh job or a human can read the spec without a checkout.`,
 
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()


### PR DESCRIPTION
The schema command's help told readers the Obmondo API renders its add-cluster form by invoking a pinned kubeaid-cli binary and parsing stdout. That was written while shelling out was still the plan; the API never runs kubeaid-cli in any form.

Consumers vendor pkg/config/schema/formspec.json, which tools/generators produces from the config structs. The command still earns its place — it prints the spec for a specific released binary, so a refresh job or a human can read it without a checkout — but the help should not point the next reader at an approach we rejected.