### PR TITLE
fix(config): keep cluster-name validation narrow at parse time

### DIFF
--- a/pkg/config/parser/validate.go
+++ b/pkg/config/parser/validate.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/version"
 
 	"github.com/Obmondo/kubeaid-cli/pkg/config"
-	"github.com/Obmondo/kubeaid-cli/pkg/config/validate"
 	"github.com/Obmondo/kubeaid-cli/pkg/constants"
 	"github.com/Obmondo/kubeaid-cli/pkg/globals"
 	repourl "github.com/Obmondo/kubeaid-cli/pkg/repository/url"
@@ -147,13 +146,24 @@ func validateACMEDNS01(cluster config.ClusterConfig, acmeCreds *config.ACMECrede
 	return nil
 }
 
-// validateClusterName runs the same rule the interactive prompt enforces
-// (pkg/config/validate.ClusterName) so a general.yaml that never went
-// through the prompt — hand-written, or rendered by the Obmondo API —
-// still fails on a dotted, oversized, or non-RFC-1123 name at parse time
-// rather than three steps later inside CAPI/Cilium.
+// validateClusterName rejects dots — the name is spliced into DNS labels
+// like the NetBird peer FQDN `k8s-<name>` and HCloud/Robot resource
+// names.
+//
+// Deliberately narrower than the interactive prompt's clusterName
+// validator (pkg/config/validate.ClusterName, which also enforces
+// RFC-1123 shape and a 63-char limit): this check runs on every `cluster`
+// subcommand via ParseConfigFiles, including sync/upgrade/delete against
+// an already-bootstrapped cluster, not just fresh config. Tightening it
+// to match the prompt needs verifying against every existing
+// kubeaid-config-<customer> general.yaml first — a name that fails the
+// stricter rule but is already running would break routine operations
+// on that cluster, not just reject a new one.
 func validateClusterName(clusterName string) error {
-	return validate.ClusterName(clusterName)
+	if strings.Contains(clusterName, ".") {
+		return errors.New("cluster name cannot contain any dots")
+	}
+	return nil
 }
 
 func validateClusterType(clusterType, cloudProviderName string) error {

--- a/pkg/config/parser/validate_test.go
+++ b/pkg/config/parser/validate_test.go
@@ -13,8 +13,6 @@ import (
 	"testing"
 	"time"
 
-	validatorV10 "github.com/go-playground/validator/v10"
-	goNonStandardValidators "github.com/go-playground/validator/v10/non-standard/validators"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -23,12 +21,41 @@ import (
 	"github.com/Obmondo/kubeaid-cli/pkg/globals"
 )
 
+// hetznerBareMetalConfigWithVLANID builds a HetznerConfig with every
+// other validate-tagged field satisfied, nesting vlanID at its real
+// production depth (HetznerConfig.BareMetal.VSwitch.VLANID) so a passing
+// test proves the whole recursion chain — not just VSwitchConfig
+// validated on its own — actually reaches it.
+func hetznerBareMetalConfigWithVLANID(vlanID int) *config.HetznerConfig {
+	return &config.HetznerConfig{
+		Mode:       constants.HetznerModeBareMetal,
+		SSHKeyPair: config.HetznerSSHKeyPair{Name: "test-key"},
+		ControlPlane: config.HetznerControlPlane{
+			Regions: []string{"fsn1"},
+		},
+		BareMetal: &config.HetznerBareMetalConfig{
+			InstallImage: config.InstallImageConfig{
+				ImagePath: "/root/.oldroot/nfs/images/test.tar.zst",
+				VG0:       config.VG0Config{Size: 80, RootVolumeSize: 50},
+			},
+			ZFS: config.ZFSConfig{Size: 220},
+			VSwitch: &config.VSwitchConfig{
+				VLANID:          vlanID,
+				Name:            "test-vswitch",
+				SubnetCIDRBlock: "10.0.1.0/24",
+			},
+		},
+	}
+}
+
 // TestVSwitchVLANIDRangeEnforcedAtParseTime proves the Hetzner vSwitch
 // VLAN ID range (4000-4091) is enforced by validateConfigStructTags —
 // the same check pkg/config/validate.HetznerVLANID runs interactively —
 // so a config that never went through the prompt (hand-written, or
 // rendered by the Obmondo API) still fails fast at parse time instead of
-// erroring against Hetzner's webservice mid-bootstrap.
+// erroring against Hetzner's webservice mid-bootstrap. Runs through
+// validateConfigStructTags itself, with VLANID nested at its real
+// production depth, rather than validating VSwitchConfig standalone.
 func TestVSwitchVLANIDRangeEnforcedAtParseTime(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -42,20 +69,15 @@ func TestVSwitchVLANIDRangeEnforcedAtParseTime(t *testing.T) {
 		{name: "zero value (unset)", vlanID: 0, wantErr: true},
 	}
 
-	validator := validatorV10.New(validatorV10.WithRequiredStructEnabled())
-	require.NoError(t, validator.RegisterValidation("notblank", goNonStandardValidators.NotBlank))
-
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			vSwitch := config.VSwitchConfig{
-				VLANID:          tc.vlanID,
-				Name:            "test-vswitch",
-				SubnetCIDRBlock: "10.0.1.0/24",
-			}
+			general := minimalLocalConfig("bm-test")
+			general.Cloud = config.CloudConfig{Hetzner: hetznerBareMetalConfigWithVLANID(tc.vlanID)}
 
-			err := validator.Struct(vSwitch)
+			err := validateConfigStructTags(general, &config.SecretsConfig{})
 			if tc.wantErr {
 				assert.Error(t, err, "VLAN ID %d should be rejected", tc.vlanID)
+				assert.Contains(t, err.Error(), "VLANID")
 				return
 			}
 			assert.NoError(t, err, "VLAN ID %d should be accepted", tc.vlanID)
@@ -166,10 +188,7 @@ func TestValidateConfigs(t *testing.T) {
 
 			err := validateConfigs(context.Background())
 			require.Error(t, err)
-			// validateClusterName delegates to pkg/config/validate.ClusterName —
-			// same rule the interactive prompt enforces (see that package's
-			// TestClusterName for the other RFC-1123 cases).
-			assert.EqualError(t, err, "cluster name cannot contain dots — use '-' instead (e.g. kam-acme-com)")
+			assert.EqualError(t, err, "cluster name cannot contain any dots")
 		})
 	}
 }


### PR DESCRIPTION
Reverts validateClusterName's delegation to pkg/config/validate.ClusterName from the previous commit. That delegation runs on every `cluster` subcommand via ParseConfigFiles — including sync/upgrade/delete/recover against an already-bootstrapped cluster, not just fresh config — and this worktree has no way to verify it against every real kubeaid-config-<customer> general.yaml. A cluster name that fails the stricter RFC-1123 + 63-char rule but is already running would break routine operations on that cluster, not just reject a new one. Back to checking only for dots, which the same audience already had to satisfy to reach a working cluster.

Also strengthens TestVSwitchVLANIDRangeEnforcedAtParseTime: it now calls validateConfigStructTags itself, with VLANID nested at its real production depth (GeneralConfig.Cloud.Hetzner.BareMetal.VSwitch.VLANID) via a minimal-but-fully-populated HetznerConfig, instead of validating VSwitchConfig standalone — the original version would have kept passing even if the recursion chain into VSwitchConfig ever broke (e.g. a `validate:"-"` added to an ancestor field).