### PR TITLE
feat(obmondo)!: bootstrap from Obmondo with --token and --certname

### DIFF
--- a/cmd/kubeaid-core/root/cluster/bootstrap.go
+++ b/cmd/kubeaid-core/root/cluster/bootstrap.go
@@ -6,6 +6,7 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -26,13 +27,26 @@ var BootstrapCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
 
-		// --connect-obmondo stands in for `config generate`: the Obmondo
-		// portal has already collected every answer, so rather than
-		// prompting, the rendered general.yaml and secrets.yaml are
-		// downloaded and written before the bootstrap below reads them.
+		// The Obmondo flags stand in for `config generate`: the portal has
+		// already collected every answer, so the rendered general.yaml and
+		// secrets.yaml are downloaded — or read back off disk — before the
+		// bootstrap below reads them.
 		var obmondoPaths *obmondo.WrittenPaths
-		if len(connectObmondoToken) > 0 {
+		switch {
+		case bootstrapToken != "" && obmondoCertname != "":
 			obmondoPaths = fetchObmondoConfig(ctx, cmd)
+
+		// A token names no cluster on its own, and the API refuses a
+		// redemption without one, so this is caught here rather than spent
+		// on a request that cannot succeed.
+		case bootstrapToken != "":
+			assert.AssertErrNil(ctx,
+				fmt.Errorf("--%s is required with --%s", constants.FlagNameCertname, constants.FlagNameToken),
+				"Refusing to bootstrap: --"+constants.FlagNameToken+" does not say which cluster it is for",
+			)
+
+		case obmondoCertname != "":
+			obmondoPaths = obmondoConfigFromDisk(ctx, cmd)
 		}
 
 		core.BootstrapCluster(ctx, core.BootstrapClusterArgs{
@@ -55,15 +69,55 @@ var BootstrapCmd = &cobra.Command{
 var skipMonitoringSetup,
 	skipClusterctlMove bool
 
-var connectObmondoToken,
+var bootstrapToken,
+	obmondoCertname,
 	obmondoAPIURL string
+
+// obmondoConfigFromDisk continues from a configuration an earlier run already
+// fetched. --certname without a token means "this cluster, whatever is on
+// disk", so nothing is downloaded and no token has to still be valid.
+//
+// An explicit --configs-directory is checked in place; without one the
+// per-cluster directories are searched for the certificate issued to this
+// certname. Either way the certificate has to match, so a stale or unrelated
+// config is refused here rather than surfacing as an authentication failure
+// deep into bootstrap.
+func obmondoConfigFromDisk(ctx context.Context, cmd *cobra.Command) *obmondo.WrittenPaths {
+	if cmd.Flags().Changed(constants.FlagNameConfigsDirectory) {
+		paths, err := obmondo.VerifyOnDisk(globals.ConfigsDirectory, obmondoCertname)
+		assert.AssertErrNil(ctx, err, "Refusing to bootstrap: no usable configuration for --"+constants.FlagNameCertname)
+
+		obmondo.LogReusedPaths(ctx, paths)
+		return paths
+	}
+
+	directory, paths, err := obmondo.FindOnDisk(obmondoCertname)
+	assert.AssertErrNil(ctx, err, "Refusing to bootstrap: no usable configuration for --"+constants.FlagNameCertname)
+
+	globals.ConfigsDirectory = directory
+	obmondo.LogReusedPaths(ctx, paths)
+	return paths
+}
 
 // fetchObmondoConfig downloads this cluster's configuration and writes it,
 // pointing globals.ConfigsDirectory at the result so the bootstrap that
 // follows reads exactly what was just written. Returns where the files
 // landed, for the end-of-run backup notice.
 func fetchObmondoConfig(ctx context.Context, cmd *cobra.Command) *obmondo.WrittenPaths {
-	config, err := obmondo.Fetch(ctx, obmondoAPIURL, connectObmondoToken)
+	// Looked up by certname before the request, because that is the only
+	// handle available this early: the configs directory is otherwise
+	// derived from the cluster name, which is inside the general.yaml that
+	// has not been downloaded yet. Informational only — the fetch proceeds
+	// either way and Write replaces what is there.
+	existingDirectory, _, err := obmondo.FindOnDisk(obmondoCertname)
+	if err == nil {
+		slog.InfoContext(ctx, "Replacing the cluster configuration already on disk",
+			slog.String("certname", obmondoCertname),
+			slog.String("directory", existingDirectory),
+		)
+	}
+
+	config, err := obmondo.Fetch(ctx, obmondoAPIURL, bootstrapToken, obmondoCertname)
 	assert.AssertErrNil(ctx, err, "Failed fetching cluster configuration from Obmondo")
 
 	clusterName, err := obmondo.ClusterName(config.GeneralYAML)
@@ -114,10 +168,20 @@ func init() {
 	// Defaulted from the environment so the token can be supplied without
 	// landing in argv, which is world-readable via ps on a shared machine.
 	BootstrapCmd.PersistentFlags().
-		StringVar(&connectObmondoToken, constants.FlagNameConnectObmondo,
-			os.Getenv(constants.EnvNameObmondoToken),
-			"Fetch this cluster's configuration from Obmondo using the token issued by the portal"+
-				" (also read from "+constants.EnvNameObmondoToken+")",
+		StringVar(&bootstrapToken, constants.FlagNameToken,
+			os.Getenv(constants.EnvNameToken),
+			"Fetch this cluster's configuration from Obmondo using the bootstrap token issued by the portal"+
+				" (also read from "+constants.EnvNameToken+")",
+		)
+
+	// Required with the token, not derivable from it: the API refuses a
+	// redemption whose certname disagrees with the one the token was issued
+	// for, and the portal hands out both together.
+	BootstrapCmd.PersistentFlags().
+		StringVar(&obmondoCertname, constants.FlagNameCertname,
+			os.Getenv(constants.EnvNameCertname),
+			"Certname the Obmondo token was issued for, as <cluster>.<customer-id>"+
+				" (also read from "+constants.EnvNameCertname+")",
 		)
 
 	BootstrapCmd.PersistentFlags().

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -60,19 +60,32 @@ const (
 	FlagNameSkipClusterctlMove  = "skip-clusterctl-move"
 	FlagNameYes                 = "yes"
 
-	// FlagNameConnectObmondo takes the single-use token the Obmondo portal's
-	// add-cluster flow issues, and fetches that cluster's rendered
+	// FlagNameToken takes the short-lived bootstrap token the Obmondo
+	// portal's add-cluster flow issues, and fetches that cluster's rendered
 	// general.yaml and secrets.yaml instead of running `config generate`.
-	FlagNameConnectObmondo = "connect-obmondo"
+	// Supplying it is what selects the Obmondo path at all.
+	FlagNameToken = "token"
+
+	// FlagNameCertname names the cluster the token was issued for, as
+	// <cluster>.<customer-id>. Required alongside the token: the API checks
+	// the two agree and refuses the redemption otherwise, so the token alone
+	// is not enough to fetch anything. The portal emits both together.
+	FlagNameCertname = "certname"
 
 	// FlagNameObmondoAPIURL overrides which Obmondo API the token is
 	// redeemed against — needed to point at beta or a local build.
 	FlagNameObmondoAPIURL = "obmondo-api-url"
 
-	// EnvNameObmondoToken supplies the same token as FlagNameConnectObmondo.
+	// EnvNameToken supplies the same bootstrap token as FlagNameToken.
 	// Preferred over the flag on a shared machine: argv is world-readable
 	// through ps, a process's environment is not.
-	EnvNameObmondoToken = "KUBEAID_CLI_OBMONDO_TOKEN"
+	EnvNameToken = "KUBEAID_CLI_TOKEN"
+
+	// EnvNameCertname supplies the same value as FlagNameCertname, so the
+	// portal can emit one export block carrying both halves of the
+	// redemption. Not a secret — it pairs with one purely for symmetry with
+	// the token it must accompany.
+	EnvNameCertname = "KUBEAID_CLI_CERTNAME"
 
 	FlagNameAWSAccessKeyID     = "aws-access-key-id"
 	FlagNameAWSSecretAccessKey = "aws-secret-access-key"

--- a/pkg/obmondo/connect.go
+++ b/pkg/obmondo/connect.go
@@ -4,9 +4,11 @@
 // Package obmondo fetches a cluster's configuration from the Obmondo portal.
 //
 // The portal's add-cluster flow collects every answer general.yaml and
-// secrets.yaml need, then issues a short-lived single-use token. Passing that
-// token to `cluster bootstrap --connect-obmondo` downloads the rendered files
-// instead of running `config generate` — the portal has already done that job.
+// secrets.yaml need, then issues a short-lived bootstrap token paired with
+// the cluster's certname. Passing both to `cluster bootstrap` downloads the
+// rendered files instead of running `config generate` — the portal has
+// already done that job. Passing the certname alone reuses whatever an
+// earlier run already fetched for it.
 package obmondo
 
 import (
@@ -26,6 +28,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/Obmondo/kubeaid-cli/pkg/cert"
+	"github.com/Obmondo/kubeaid-cli/pkg/config/clusterdir"
 	"github.com/Obmondo/kubeaid-cli/pkg/constants"
 	"github.com/Obmondo/kubeaid-cli/pkg/utils/progress"
 )
@@ -36,7 +39,9 @@ const (
 	DefaultAPIURL = "https://api.obmondo.com/api"
 
 	// installPath is the token-authenticated endpoint. It carries no JWT:
-	// the token IS the authentication, and it is single-use.
+	// the token IS the authentication, paired with the certname it was
+	// issued for. Redeeming does not consume it — it stays usable until it
+	// expires, so a re-run needs no new link.
 	installPath = "/v1/cluster/install"
 
 	// fetchTimeout bounds the whole exchange. The response is a handful of
@@ -52,6 +57,9 @@ const (
 	certFileName = "cert.pem"
 	keyFileName  = "key.pem"
 	caFileName   = "ca.pem"
+
+	generalFileName = "general.yaml"
+	secretsFileName = "secrets.yaml"
 )
 
 // PuppetMaterial is the mTLS identity kubeaid-agent authenticates to Obmondo
@@ -116,14 +124,25 @@ func ClusterName(generalYAML string) (string, error) {
 
 // Fetch downloads the cluster configuration for token.
 //
+// certname must be the one the token was issued for. It is checked
+// server-side, so sending the wrong one is refused rather than silently
+// serving another cluster's config — which is why it is required here and
+// not derived from the response: the response is what the check protects.
+//
 // The token is sent as a header rather than only in the query string: it
 // keeps the secret out of any intermediary's request log, which routinely
 // records URLs and rarely records headers. The query parameter is kept as
 // well because the portal's endpoint reads it there, matching how the
 // LinuxAid install link already works.
-func Fetch(ctx context.Context, apiURL, token string) (*ClusterConfig, error) {
+func Fetch(ctx context.Context, apiURL, token, certname string) (*ClusterConfig, error) {
 	if strings.TrimSpace(token) == "" {
 		return nil, fmt.Errorf("no Obmondo token supplied")
+	}
+	if strings.TrimSpace(certname) == "" {
+		return nil, fmt.Errorf(
+			"no certname supplied: pass --%s (or set %s) with the value the portal issued alongside the token",
+			constants.FlagNameCertname, constants.EnvNameCertname,
+		)
 	}
 
 	endpoint, err := url.Parse(strings.TrimRight(apiURL, "/") + installPath)
@@ -132,6 +151,7 @@ func Fetch(ctx context.Context, apiURL, token string) (*ClusterConfig, error) {
 	}
 	query := endpoint.Query()
 	query.Set("token", token)
+	query.Set("certname", certname)
 	endpoint.RawQuery = query.Encode()
 
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
@@ -160,11 +180,13 @@ func Fetch(ctx context.Context, apiURL, token string) (*ClusterConfig, error) {
 		// fall through
 
 	case http.StatusUnauthorized, http.StatusNotFound, http.StatusGone:
-		// One message for every "this token will not work" case. The token
-		// is single-use and short-lived, so an operator hitting any of
-		// these needs the same next step: get a fresh one from the portal.
+		// One message for every "this will not work" case. The API answers
+		// an expired token and a certname that does not match the token
+		// identically and on purpose, so there is nothing to tell apart
+		// here — and either way the next step is the same.
 		return nil, fmt.Errorf(
-			"this token is not valid — it may have expired or already been used; generate a new one from the Obmondo portal",
+			"this token is not valid for %q — it may have expired, or been issued for a different cluster;"+
+				" generate a new link from the Obmondo portal", certname,
 		)
 
 	default:
@@ -209,8 +231,9 @@ func Fetch(ctx context.Context, apiURL, token string) (*ClusterConfig, error) {
 // stops deriving one from the other.
 //
 // Checked at fetch rather than at template time so an unusable certificate
-// fails now, while the operator still has the terminal — discovering it during
-// bootstrap would waste a single-use token and several minutes.
+// fails now, while the operator still has the terminal — discovering it
+// during bootstrap would cost several minutes on a config that was never
+// going to authenticate.
 func adoptCertificateCN(material *PuppetMaterial) error {
 	if material == nil || strings.TrimSpace(material.Certificate) == "" {
 		return nil
@@ -228,39 +251,114 @@ func adoptCertificateCN(material *PuppetMaterial) error {
 	return nil
 }
 
+// pathsIn returns where each file a fetch writes lives under
+// configsDirectory, whether or not any of them exist yet.
+func pathsIn(configsDirectory string) *WrittenPaths {
+	obmondoDir := filepath.Join(configsDirectory, obmondoDirName)
+	return &WrittenPaths{
+		General:  filepath.Join(configsDirectory, generalFileName),
+		Secrets:  filepath.Join(configsDirectory, secretsFileName),
+		CertPath: filepath.Join(obmondoDir, certFileName),
+		KeyPath:  filepath.Join(obmondoDir, keyFileName),
+		CAPath:   filepath.Join(obmondoDir, caFileName),
+	}
+}
+
+// Complete reports whether every file a fetch writes is present under
+// configsDirectory. All of them or none is the only useful answer: a
+// half-written directory cannot bootstrap, and treating it as usable would
+// fail much later with a much worse message.
+func Complete(configsDirectory string) (*WrittenPaths, bool) {
+	paths := pathsIn(configsDirectory)
+	for _, path := range []string{paths.General, paths.Secrets, paths.CertPath, paths.KeyPath, paths.CAPath} {
+		if _, err := os.Stat(path); err != nil {
+			return paths, false
+		}
+	}
+	return paths, true
+}
+
+// VerifyOnDisk accepts configsDirectory as this run's configuration, if it
+// holds a complete file set whose Puppet certificate was issued for
+// certname.
+//
+// The certificate's CN decides, never the directory's name: a cluster's name
+// and its certname are separate identifiers (see adoptCertificateCN), so a
+// path that looks right proves nothing about who the config authenticates
+// as.
+func VerifyOnDisk(configsDirectory, certname string) (*WrittenPaths, error) {
+	paths, complete := Complete(configsDirectory)
+	if !complete {
+		return nil, fmt.Errorf(
+			"%s does not hold a complete Obmondo configuration — pass --%s to fetch one",
+			configsDirectory, constants.FlagNameToken,
+		)
+	}
+
+	cn, err := cert.ReadCN(paths.CertPath)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", paths.CertPath, err)
+	}
+	if cn != certname {
+		return nil, fmt.Errorf(
+			"the certificate in %s was issued for %q, not %q",
+			configsDirectory, cn, certname,
+		)
+	}
+
+	return paths, nil
+}
+
+// FindOnDisk locates the configuration a previous run fetched for certname,
+// among the per-cluster directories kubeaid-cli writes.
+//
+// Scans rather than deriving a path from certname, for the reason in
+// VerifyOnDisk: the certificate's CN is the only reliable link between a
+// certname and a directory named after a cluster.
+func FindOnDisk(certname string) (string, *WrittenPaths, error) {
+	clusters := clusterdir.List()
+
+	for _, cluster := range clusters {
+		directory, err := clusterdir.For(cluster)
+		if err != nil {
+			continue
+		}
+		paths, err := VerifyOnDisk(directory, certname)
+		if err != nil {
+			continue
+		}
+		return directory, paths, nil
+	}
+
+	if len(clusters) == 0 {
+		return "", nil, fmt.Errorf(
+			"no cluster configuration on this machine — pass --%s to fetch %s from Obmondo",
+			constants.FlagNameToken, certname,
+		)
+	}
+	return "", nil, fmt.Errorf(
+		"nothing on this machine was issued for %s (found: %s) — pass --%s to fetch it",
+		certname, strings.Join(clusters, ", "), constants.FlagNameToken,
+	)
+}
+
 // Write lays the configuration out under configsDirectory and returns where
 // each file landed.
 //
-// It refuses to overwrite an existing general.yaml. A token is single-use, so
-// finding config already there means either a previous run succeeded — in
-// which case bootstrap should simply be re-run without the flag — or there is
-// unrelated config here that silently replacing would destroy.
+// Existing files are overwritten. Redeeming a token is repeatable within its
+// window, so a caller that got this far asked for this cluster's config by
+// certname and got it — replacing what an earlier run wrote for the same
+// certname is the intent, not an accident. Prompting instead would ask the
+// same question on every re-run, which is the case most likely to be
+// answered by reflex.
 func Write(configsDirectory string, config *ClusterConfig) (*WrittenPaths, error) {
-	generalPath := filepath.Join(configsDirectory, "general.yaml")
-
-	_, err := os.Stat(generalPath)
-	if err == nil {
-		// Not "re-run without --connect-obmondo": the token path resolves to
-		// a per-cluster directory, so dropping the flag would send bootstrap
-		// looking in outputs/configs and it would not find this at all.
-		return nil, fmt.Errorf(
-			"%s already exists — re-run bootstrap with --%s %s to use it",
-			generalPath, constants.FlagNameConfigsDirectory, configsDirectory,
-		)
-	}
-	// Anything other than "not there" is a real problem — an unreadable
-	// directory, say. Only a genuine absence means it is safe to write.
-	if !os.IsNotExist(err) {
-		return nil, fmt.Errorf("checking %s: %w", generalPath, err)
-	}
-
 	if err := os.MkdirAll(configsDirectory, 0o700); err != nil {
 		return nil, fmt.Errorf("creating %s: %w", configsDirectory, err)
 	}
 
 	written := &WrittenPaths{
-		General: generalPath,
-		Secrets: filepath.Join(configsDirectory, "secrets.yaml"),
+		General: filepath.Join(configsDirectory, generalFileName),
+		Secrets: filepath.Join(configsDirectory, secretsFileName),
 	}
 
 	// secrets.yaml and the private key are 0600 throughout: they carry the
@@ -351,6 +449,16 @@ func withObmondoCertPaths(generalYAML, certPath, keyPath string) string {
 	}
 
 	return strings.Join(lines, "\n")
+}
+
+// LogReusedPaths reports the configuration an offline run adopted — the
+// --certname-only path, where nothing was downloaded and nothing replaced.
+func LogReusedPaths(ctx context.Context, written *WrittenPaths) {
+	slog.InfoContext(ctx, "Using the cluster configuration already on disk",
+		slog.String("general", written.General),
+		slog.String("secrets", written.Secrets),
+		slog.String("obmondoCert", written.CertPath),
+	)
 }
 
 // LogPaths reports what was written, without echoing any contents.

--- a/pkg/obmondo/connect_test.go
+++ b/pkg/obmondo/connect_test.go
@@ -24,7 +24,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const testToken = "tok_9f3c1a7e5b2d4088"
+const (
+	testToken = "tok_9f3c1a7e5b2d4088"
+
+	// testCertname is the <cluster>.<customer-id> the token was issued for.
+	// Sent on every redemption: the API refuses one whose certname disagrees
+	// with the token's.
+	testCertname = "demo.acme"
+)
 
 // testCertPEM mints a self-signed certificate carrying cn as its Subject
 // Common Name. Real x509 rather than a fixture string, because what is under
@@ -58,16 +65,17 @@ const testConfigData = `{
 }`
 
 func TestFetchReturnsTheConfigAndSendsTheTokenBothWays(t *testing.T) {
-	var gotHeader, gotQuery string
+	var gotHeader, gotQuery, gotCertname string
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotHeader = r.Header.Get("token")
 		gotQuery = r.URL.Query().Get("token")
+		gotCertname = r.URL.Query().Get("certname")
 		_, _ = w.Write([]byte(okEnvelope(testConfigData)))
 	}))
 	defer server.Close()
 
-	config, err := Fetch(context.Background(), server.URL, testToken)
+	config, err := Fetch(context.Background(), server.URL, testToken, testCertname)
 	require.NoError(t, err)
 	require.Equal(t, "cluster:\n  name: demo\n", config.GeneralYAML)
 	require.Contains(t, config.SecretsYAML, "apiToken")
@@ -77,21 +85,26 @@ func TestFetchReturnsTheConfigAndSendsTheTokenBothWays(t *testing.T) {
 	// the query parameter is what the portal's endpoint reads.
 	require.Equal(t, testToken, gotHeader)
 	require.Equal(t, testToken, gotQuery)
+
+	// The API gates redemption on this matching the token's own certname, so
+	// omitting it is a validation failure rather than a permissive default.
+	require.Equal(t, testCertname, gotCertname)
 }
 
-// A token that will not work — expired, already used, or simply wrong — must
-// produce one actionable message rather than leaking which case applied.
+// A token that will not work — expired, simply wrong, or issued for another
+// cluster — must produce one actionable message rather than leaking which
+// case applied.
 func TestFetchTreatsEveryDeadTokenTheSame(t *testing.T) {
 	for _, status := range []int{http.StatusUnauthorized, http.StatusNotFound, http.StatusGone} {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(status)
 		}))
 
-		_, err := Fetch(context.Background(), server.URL, testToken)
+		_, err := Fetch(context.Background(), server.URL, testToken, testCertname)
 		server.Close()
 
 		require.Errorf(t, err, "status %d", status)
-		require.Containsf(t, err.Error(), "generate a new one", "status %d", status)
+		require.Containsf(t, err.Error(), "generate a new link", "status %d", status)
 	}
 }
 
@@ -113,7 +126,7 @@ func TestFetchNeverPutsTheTokenInAnError(t *testing.T) {
 			server := httptest.NewServer(handler)
 			defer server.Close()
 
-			_, err := Fetch(context.Background(), server.URL, testToken)
+			_, err := Fetch(context.Background(), server.URL, testToken, testCertname)
 			require.Error(t, err)
 			require.NotContains(t, err.Error(), testToken)
 		})
@@ -121,7 +134,7 @@ func TestFetchNeverPutsTheTokenInAnError(t *testing.T) {
 
 	// An unreachable host is the case most likely to embed the URL, and the
 	// URL carries the token in its query string.
-	_, err := Fetch(context.Background(), "http://127.0.0.1:1", testToken)
+	_, err := Fetch(context.Background(), "http://127.0.0.1:1", testToken, testCertname)
 	require.Error(t, err)
 	require.NotContains(t, err.Error(), testToken)
 }
@@ -144,13 +157,14 @@ func TestFetchTakesTheCertnameFromTheCertificateCN(t *testing.T) {
 	}))
 	defer server.Close()
 
-	config, err := Fetch(context.Background(), server.URL, testToken)
+	config, err := Fetch(context.Background(), server.URL, testToken, testCertname)
 	require.NoError(t, err)
 	require.Equal(t, "k8s-demo.acme", config.Puppet.Certname)
 }
 
 // An unusable certificate must fail now, not minutes into bootstrap when
-// cert.ReadCN hits it — by then the single-use token is already spent.
+// cert.ReadCN hits it — by then a lot of work has happened on a config that
+// was never going to authenticate.
 func TestFetchRejectsAnUnparseableCertificate(t *testing.T) {
 	body := okEnvelope(`{
 	  "general_yaml": "cluster:\n  name: demo-01\n",
@@ -163,7 +177,7 @@ func TestFetchRejectsAnUnparseableCertificate(t *testing.T) {
 	}))
 	defer server.Close()
 
-	_, err := Fetch(context.Background(), server.URL, testToken)
+	_, err := Fetch(context.Background(), server.URL, testToken, testCertname)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unusable Puppet certificate")
 	require.NotContains(t, err.Error(), testToken)
@@ -176,14 +190,23 @@ func TestFetchAllowsAMissingPuppetBlock(t *testing.T) {
 	}))
 	defer server.Close()
 
-	config, err := Fetch(context.Background(), server.URL, testToken)
+	config, err := Fetch(context.Background(), server.URL, testToken, testCertname)
 	require.NoError(t, err)
 	require.Nil(t, config.Puppet)
 }
 
 func TestFetchRejectsAnEmptyToken(t *testing.T) {
-	_, err := Fetch(context.Background(), "https://example.invalid", "   ")
+	_, err := Fetch(context.Background(), "https://example.invalid", "   ", testCertname)
 	require.Error(t, err)
+}
+
+// Caught before the request rather than as a 406 from the API, so the
+// operator is told which value is missing instead of reading a validation
+// failure back out of an envelope.
+func TestFetchRejectsAnEmptyCertname(t *testing.T) {
+	_, err := Fetch(context.Background(), "https://example.invalid", testToken, "   ")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "certname")
 }
 
 func TestClusterNameReadsTheNameAndToleratesUnknownFields(t *testing.T) {
@@ -222,24 +245,79 @@ func TestWriteLaysOutTheFilesWithRestrictivePermissions(t *testing.T) {
 	require.Equal(t, os.FileMode(0o700), dirInfo.Mode().Perm())
 }
 
-// The token is single-use, so an existing general.yaml means either a previous
-// run succeeded or unrelated config lives here. Overwriting either silently
-// would destroy work.
-func TestWriteRefusesToClobberExistingConfig(t *testing.T) {
+// A token is redeemable for its whole window, so a re-run reaching Write has
+// deliberately asked for this certname's config again. Replacing what is
+// there is the intent — prompting would ask the same question every re-run.
+func TestWriteOverwritesExistingConfig(t *testing.T) {
 	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "general.yaml"), []byte("existing"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "general.yaml"), []byte("stale"), 0o600))
 
-	_, err := Write(dir, &ClusterConfig{GeneralYAML: "cluster:\n  name: demo\n"})
-	require.Error(t, err)
-
-	// Must name the directory it actually looked in. Telling the operator to
-	// "re-run without --connect-obmondo" would send bootstrap to
-	// outputs/configs, which is not where this file is.
-	require.Contains(t, err.Error(), "--configs-directory "+dir)
-
-	kept, err := os.ReadFile(filepath.Join(dir, "general.yaml"))
+	written, err := Write(dir, &ClusterConfig{
+		GeneralYAML: "cluster:\n  name: demo\n",
+		SecretsYAML: "hetzner:\n  apiToken: tok\n",
+	})
 	require.NoError(t, err)
-	require.Equal(t, "existing", string(kept))
+
+	replaced, err := os.ReadFile(written.General)
+	require.NoError(t, err)
+	require.Equal(t, "cluster:\n  name: demo\n", string(replaced))
+}
+
+// A directory missing any one of the five files cannot bootstrap, so a
+// partial set must read as absent rather than as something to work with.
+func TestCompleteRequiresEveryFile(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "configs")
+	written, err := Write(dir, &ClusterConfig{
+		GeneralYAML: "cluster:\n  name: demo\n",
+		SecretsYAML: "x",
+		Puppet: &PuppetMaterial{
+			Certificate:   testCertPEM(t, testCertname),
+			PrivateKey:    "k",
+			CACertificate: "ca",
+		},
+	})
+	require.NoError(t, err)
+
+	_, complete := Complete(dir)
+	require.True(t, complete)
+
+	require.NoError(t, os.Remove(written.KeyPath))
+	_, complete = Complete(dir)
+	require.False(t, complete, "a missing private key must make the set incomplete")
+}
+
+// The certificate's CN is what ties a directory to a certname — the
+// directory's own name proves nothing, since a cluster's name and its
+// certname are separate identifiers.
+func TestVerifyOnDiskMatchesOnTheCertificateCN(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "configs")
+	_, err := Write(dir, &ClusterConfig{
+		GeneralYAML: "cluster:\n  name: something-else\n",
+		SecretsYAML: "x",
+		Puppet: &PuppetMaterial{
+			Certificate:   testCertPEM(t, testCertname),
+			PrivateKey:    "k",
+			CACertificate: "ca",
+		},
+	})
+	require.NoError(t, err)
+
+	paths, err := VerifyOnDisk(dir, testCertname)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(dir, "general.yaml"), paths.General)
+
+	_, err = VerifyOnDisk(dir, "other.acme")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), testCertname)
+}
+
+func TestVerifyOnDiskRejectsAnIncompleteDirectory(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "general.yaml"), []byte("cluster:\n  name: demo\n"), 0o600))
+
+	_, err := VerifyOnDisk(dir, testCertname)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "--token")
 }
 
 func TestWriteStoresPuppetMaterialAndPointsGeneralAtIt(t *testing.T) {


### PR DESCRIPTION
## Why

The Obmondo API now gates install-link redemption on `certname`. A token alone no longer selects which cluster's config to serve, and a request whose certname disagrees with the one the token was issued for is refused. `Fetch` sent only the token, so every redemption would have failed validation.

## What

`cluster bootstrap` dispatches on which of the two Obmondo flags are present:

| flags | behaviour |
| --- | --- |
| `--token` + `--certname` | fetch from the API and write, replacing what is there |
| `--token` only | refused up front — a token names no cluster, and the API will not redeem one without a certname |
| `--certname` only | reuse whatever an earlier run already fetched; no network call |
| neither | unchanged — `config generate` / `--configs-directory` |

```
kubeaid-cli cluster bootstrap --token <token> --certname <cluster>.<customer-id>
```

**The offline path matches on the CN inside the Puppet certificate**, not on a directory named after a cluster. A cluster's name and its certname are separate identifiers, so a path that looks right proves nothing about who the config authenticates as. Without an explicit `--configs-directory` the per-cluster directories are searched for the certificate issued to this certname; with one, that directory is checked in place. Either way a stale or unrelated config is refused immediately instead of surfacing as an authentication failure minutes into bootstrap.

**`Write` no longer refuses to overwrite.** It refused because a token was single-use, so an existing `general.yaml` had to mean either a finished run or unrelated config. Redemption is repeatable within the token's window now, so a caller reaching `Write` asked for this certname's config again and replacing it is the intent. Prompting instead would ask the same question on every re-run — the case most likely to be answered by reflex.

An empty certname is caught before the request goes out, so the operator is told which value is missing rather than reading a 406 back out of a response envelope.

## Also

Stale wording from when the token was going to be single-use is gone throughout — the package doc, `installPath`, `adoptCertificateCN`, and the dead-token message, which now names the cluster and covers *"issued for a different cluster"* (a certname mismatch returns 401, which the old text blamed on expiry).

## Ordering

Safe to merge before the API change. Sending `certname` is accepted by today's API — it already reads the parameter, it just doesn't require it yet — so this is forward-compatible, whereas the API change is not.

The portal also needs to emit `--certname` in the command it shows operators. The issued URL already carries the value (`...install?token=…&certname=…`).

## Breaking

- `--connect-obmondo` → `--token`, and it now requires `--certname` (or `KUBEAID_CLI_CERTNAME`)
- `KUBEAID_CLI_OBMONDO_TOKEN` → `KUBEAID_CLI_TOKEN`

`--connect-obmondo` shipped yesterday in d30e0fce, so the blast radius is small.

## Testing

`go build ./...`, `go vet`, and the full `go test ./...` suite pass. New coverage: certname is actually sent on the wire, an empty one is rejected early, `Complete` requires every file, `VerifyOnDisk` matches on the certificate CN and rejects an incomplete directory, and `Write` overwrites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)