### PR TITLE
feat(config): let an opensource user enable monitoring without Obmondo certs

### DIFF
--- a/pkg/config/parser/validate.go
+++ b/pkg/config/parser/validate.go
@@ -26,6 +26,7 @@ import (
 	kubeonessh "k8c.io/kubeone/pkg/ssh"
 	"k8s.io/apimachinery/pkg/util/version"
 
+	"github.com/Obmondo/kubeaid-cli/pkg/cert"
 	"github.com/Obmondo/kubeaid-cli/pkg/config"
 	"github.com/Obmondo/kubeaid-cli/pkg/config/validate"
 	"github.com/Obmondo/kubeaid-cli/pkg/constants"
@@ -332,6 +333,15 @@ func validateObmondoMonitoring(
 	}
 	if _, err := stat(obmondo.KeyPath); err != nil {
 		return fmt.Errorf("obmondo.keyPath does not exist: %w", err)
+	}
+
+	// Parsed once here rather than at every render site: templates.go reads
+	// the CN out of this file to stamp into cluster-vars, so a file that is
+	// present but is not a certificate would otherwise surface midway
+	// through rendering instead of while the operator is still looking at
+	// their config.
+	if _, err := cert.ReadCN(obmondo.CertPath); err != nil {
+		return fmt.Errorf("obmondo.certPath is not a readable X.509 certificate: %w", err)
 	}
 
 	return nil

--- a/pkg/config/parser/validate.go
+++ b/pkg/config/parser/validate.go
@@ -294,23 +294,41 @@ func validateObmondoMonitoring(
 	obmondo *config.ObmondoConfig,
 	stat statFunc,
 ) error {
-	if obmondo == nil || !obmondo.Monitoring {
+	if obmondo == nil {
 		return nil
 	}
-	if obmondo.CertPath == "" {
+
+	// obmondo.monitoring no longer requires a certificate. It asks for
+	// kube-prometheus, which an opensource user is entitled to — the
+	// Obmondo-side wiring (client cert secret, alertmanager push, the
+	// KubeAid Agent app) keys off the certificate being present instead,
+	// see config.ObmondoIntegrationEnabled.
+	//
+	// What is still validated is that the pair is coherent: half a pair is
+	// always a mistake, and a path that points at nothing would otherwise
+	// surface as an unreadable file midway through rendering.
+	certSet := obmondo.CertPath != ""
+	keySet := obmondo.KeyPath != ""
+
+	switch {
+	case certSet && !keySet:
 		return errors.New(
-			"obmondo.monitoring is true but obmondo.certPath is empty, " +
-				"an Obmondo-issued mTLS cert is required",
+			"obmondo.certPath is set but obmondo.keyPath is empty, " +
+				"the private key paired with the certificate is required",
 		)
+
+	case keySet && !certSet:
+		return errors.New(
+			"obmondo.keyPath is set but obmondo.certPath is empty, " +
+				"the certificate paired with the private key is required",
+		)
+
+	case !certSet && !keySet:
+		return nil
 	}
+
 	if _, err := stat(obmondo.CertPath); err != nil {
 		return fmt.Errorf("obmondo.certPath does not exist: %w", err)
-	}
-	if obmondo.KeyPath == "" {
-		return errors.New(
-			"obmondo.monitoring is true but obmondo.keyPath is empty, " +
-				"the private key paired with obmondo.certPath is required",
-		)
 	}
 	if _, err := stat(obmondo.KeyPath); err != nil {
 		return fmt.Errorf("obmondo.keyPath does not exist: %w", err)

--- a/pkg/config/parser/validate_test.go
+++ b/pkg/config/parser/validate_test.go
@@ -5,8 +5,14 @@ package parser
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"errors"
 	"fmt"
+	"math/big"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1027,12 +1033,28 @@ func TestValidateObmondoMonitoringConfig(t *testing.T) {
 			name: "valid Cert + Key passes",
 			setup: func(t *testing.T) *config.ObmondoConfig {
 				dir := t.TempDir()
-				cert := filepath.Join(dir, "c.pem")
+				certPath := filepath.Join(dir, "c.pem")
 				key := filepath.Join(dir, "k.pem")
-				require.NoError(t, os.WriteFile(cert, []byte("c"), 0o600))
+				require.NoError(t, os.WriteFile(certPath, testCertPEM(t, "demo.acme"), 0o600))
 				require.NoError(t, os.WriteFile(key, []byte("k"), 0o600))
-				return &config.ObmondoConfig{Monitoring: true, CertPath: cert, KeyPath: key}
+				return &config.ObmondoConfig{Monitoring: true, CertPath: certPath, KeyPath: key}
 			},
+		},
+		{
+			// A file that exists but is not a certificate would otherwise
+			// surface as a render failure, after the operator has stopped
+			// looking at their config.
+			name: "a certPath that is not an X.509 cert is rejected",
+			setup: func(t *testing.T) *config.ObmondoConfig {
+				dir := t.TempDir()
+				certPath := filepath.Join(dir, "c.pem")
+				key := filepath.Join(dir, "k.pem")
+				require.NoError(t, os.WriteFile(certPath, []byte("not a certificate"), 0o600))
+				require.NoError(t, os.WriteFile(key, []byte("k"), 0o600))
+				return &config.ObmondoConfig{Monitoring: true, CertPath: certPath, KeyPath: key}
+			},
+			wantErr:    true,
+			wantErrSub: "not a readable X.509 certificate",
 		},
 	}
 
@@ -1261,4 +1283,25 @@ func TestValidateBareMetalConfigRejectsZeroControlPlaneHosts(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "control-plane hosts")
+}
+
+// testCertPEM mints a self-signed certificate carrying cn, so validation
+// that parses the file has something real to parse.
+func testCertPEM(t *testing.T, cn string) []byte {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
 }

--- a/pkg/config/parser/validate_test.go
+++ b/pkg/config/parser/validate_test.go
@@ -982,9 +982,21 @@ func TestValidateObmondoMonitoringConfig(t *testing.T) {
 		wantErrSub string
 	}{
 		{
-			name: "empty CertPath is rejected",
+			// monitoring alone is an opensource-legal request for
+			// kube-prometheus; the Obmondo wiring keys off the certificate
+			// instead (see config.ObmondoIntegrationEnabled).
+			name: "monitoring without any cert is allowed",
 			setup: func(t *testing.T) *config.ObmondoConfig {
 				return &config.ObmondoConfig{Monitoring: true}
+			},
+			wantErr: false,
+		},
+		{
+			name: "a key without its certificate is rejected",
+			setup: func(t *testing.T) *config.ObmondoConfig {
+				keyPath := filepath.Join(t.TempDir(), "key.pem")
+				require.NoError(t, os.WriteFile(keyPath, []byte("k"), 0o600))
+				return &config.ObmondoConfig{Monitoring: true, KeyPath: keyPath}
 			},
 			wantErr:    true,
 			wantErrSub: "obmondo.certPath is empty",
@@ -1118,12 +1130,11 @@ func TestValidateConfigHelpers(t *testing.T) {
 			wantErrSub: "alice",
 		},
 		{
-			name: "Obmondo monitoring requires cert path",
+			name: "Obmondo monitoring alone needs no cert",
 			validate: func() error {
 				return validateObmondoMonitoring(&config.ObmondoConfig{Monitoring: true}, statOK)
 			},
-			wantErr:    true,
-			wantErrSub: "certPath",
+			wantErr: false,
 		},
 		{
 			name: "Obmondo monitoring requires key path",

--- a/pkg/config/predicates.go
+++ b/pkg/config/predicates.go
@@ -153,24 +153,28 @@ func RookCephEnabled() bool {
 		(HetznerBareMetalWorkerNodeCount() >= constants.RookCephMinNodes)
 }
 
-// ObmondoIntegrationEnabled reports whether this cluster pushes to Obmondo.
+// ObmondoIntegrationEnabled reports whether this cluster pushes to Obmondo:
+// monitoring was asked for, and the mTLS material to authenticate with is on
+// disk.
 //
-// The certificate alone decides. It is minted by the portal and written by
-// `cluster bootstrap --token`, and the API mints it only when monitoring was
-// requested AND the cluster has an active subscription — it answers 402
-// before issuing anything otherwise. So its presence already carries both
-// facts, and re-checking obmondo.monitoring here would add nothing: the
-// template writes certPath and keyPath unconditionally, leaving them empty
-// exactly when the API returned no Puppet material.
+// Cheap on purpose — it is called from several render paths. That the
+// certificate is a parseable X.509 is checked once at parse time by
+// validateObmondoMonitoring, so by the time this runs, a non-empty CertPath
+// means a real certificate.
 //
-// Reading the certificate rather than the flags also survives a later re-run
-// that carries no token, which is when this is usually evaluated.
+// The material is what distinguishes an Obmondo customer from an opensource
+// user: it is minted by the portal and written by `cluster bootstrap
+// --token`, and the API refuses to mint one without an active subscription.
 //
-// obmondo.monitoring on its own therefore requires no certificate. An
-// opensource user can set it and get kube-prometheus, which is gated
-// separately by --skip-monitoring-setup and general.kubePrometheus; they
-// simply get none of the Obmondo-side wiring.
+// obmondo.monitoring on its own requires no certificate. An opensource user
+// can set it and get kube-prometheus, gated separately by
+// --skip-monitoring-setup and general.kubePrometheus; they simply get none
+// of the Obmondo-side wiring, which would otherwise render a SealedSecret
+// out of empty paths and fail the ArgoCD sync.
 func ObmondoIntegrationEnabled() bool {
 	obmondo := ParsedGeneralConfig.Obmondo
-	return obmondo != nil && obmondo.CertPath != "" && obmondo.KeyPath != ""
+	return obmondo != nil &&
+		obmondo.Monitoring &&
+		obmondo.CertPath != "" &&
+		obmondo.KeyPath != ""
 }

--- a/pkg/config/predicates.go
+++ b/pkg/config/predicates.go
@@ -153,24 +153,24 @@ func RookCephEnabled() bool {
 		(HetznerBareMetalWorkerNodeCount() >= constants.RookCephMinNodes)
 }
 
-// ObmondoIntegrationEnabled reports whether this cluster pushes to Obmondo:
-// the operator asked for it, and the mTLS material to authenticate with is
-// on disk.
+// ObmondoIntegrationEnabled reports whether this cluster pushes to Obmondo.
 //
-// The certificate is the discriminator, not the flag alone. It is issued by
-// the portal and written by `cluster bootstrap --token`, so its presence is
-// what actually distinguishes an Obmondo customer from an opensource user —
-// and unlike the flag, it still says so on a later re-run that carries no
-// token.
+// The certificate alone decides. It is minted by the portal and written by
+// `cluster bootstrap --token`, and the API mints it only when monitoring was
+// requested AND the cluster has an active subscription — it answers 402
+// before issuing anything otherwise. So its presence already carries both
+// facts, and re-checking obmondo.monitoring here would add nothing: the
+// template writes certPath and keyPath unconditionally, leaving them empty
+// exactly when the API returned no Puppet material.
 //
-// obmondo.monitoring on its own no longer requires a certificate. An
+// Reading the certificate rather than the flags also survives a later re-run
+// that carries no token, which is when this is usually evaluated.
+//
+// obmondo.monitoring on its own therefore requires no certificate. An
 // opensource user can set it and get kube-prometheus, which is gated
 // separately by --skip-monitoring-setup and general.kubePrometheus; they
-// simply get none of the Obmondo-side wiring below it.
+// simply get none of the Obmondo-side wiring.
 func ObmondoIntegrationEnabled() bool {
 	obmondo := ParsedGeneralConfig.Obmondo
-	return obmondo != nil &&
-		obmondo.Monitoring &&
-		obmondo.CertPath != "" &&
-		obmondo.KeyPath != ""
+	return obmondo != nil && obmondo.CertPath != "" && obmondo.KeyPath != ""
 }

--- a/pkg/config/predicates.go
+++ b/pkg/config/predicates.go
@@ -152,3 +152,25 @@ func RookCephEnabled() bool {
 	return UsingHetznerBareMetal() &&
 		(HetznerBareMetalWorkerNodeCount() >= constants.RookCephMinNodes)
 }
+
+// ObmondoIntegrationEnabled reports whether this cluster pushes to Obmondo:
+// the operator asked for it, and the mTLS material to authenticate with is
+// on disk.
+//
+// The certificate is the discriminator, not the flag alone. It is issued by
+// the portal and written by `cluster bootstrap --token`, so its presence is
+// what actually distinguishes an Obmondo customer from an opensource user —
+// and unlike the flag, it still says so on a later re-run that carries no
+// token.
+//
+// obmondo.monitoring on its own no longer requires a certificate. An
+// opensource user can set it and get kube-prometheus, which is gated
+// separately by --skip-monitoring-setup and general.kubePrometheus; they
+// simply get none of the Obmondo-side wiring below it.
+func ObmondoIntegrationEnabled() bool {
+	obmondo := ParsedGeneralConfig.Obmondo
+	return obmondo != nil &&
+		obmondo.Monitoring &&
+		obmondo.CertPath != "" &&
+		obmondo.KeyPath != ""
+}

--- a/pkg/core/setup_cluster.go
+++ b/pkg/core/setup_cluster.go
@@ -92,7 +92,7 @@ func SetupCluster(ctx context.Context, args SetupClusterArgs) {
 	// The monitoring namespace itself is created by kube-prometheus at
 	// sync-order 50 — so without pre-creating it here, the secrets App deadlocks
 	// and kube-prometheus never gets a chance to sync.
-	if config.ParsedGeneralConfig.Obmondo != nil && config.ParsedGeneralConfig.Obmondo.Monitoring {
+	if config.ObmondoIntegrationEnabled() {
 		namespacesToBeCreated = append(namespacesToBeCreated, "monitoring")
 	}
 	// On VPN clusters, kubeaid-cli pre-creates the namespaces so its

--- a/pkg/core/templates.go
+++ b/pkg/core/templates.go
@@ -332,7 +332,7 @@ func getTemplateValues(ctx context.Context) *TemplateValues {
 	// sealed-secret templates can base64-encode them. Paths are validated by
 	// validateConfigs — re-read here to fail with context if they became
 	// unreadable between parse and render.
-	if config.ParsedGeneralConfig.Obmondo != nil && config.ParsedGeneralConfig.Obmondo.Monitoring {
+	if config.ObmondoIntegrationEnabled() {
 		obmondo := config.ParsedGeneralConfig.Obmondo
 
 		cn, certErr := cert.ReadCN(obmondo.CertPath)
@@ -688,7 +688,7 @@ func getEmbeddedNonSecretTemplateNames() []string {
 
 	// Obmondo customer: include the KubeAid Agent ArgoCD Application
 	// templates when monitoring is requested.
-	if config.ParsedGeneralConfig.Obmondo != nil && config.ParsedGeneralConfig.Obmondo.Monitoring {
+	if config.ObmondoIntegrationEnabled() {
 		embeddedTemplateNames = append(embeddedTemplateNames,
 			constants.KubeAidAgentNonSecretTemplateNames...,
 		)
@@ -813,7 +813,7 @@ func getEmbeddedSecretTemplateNames() []string {
 		// No additional provider-specific secret templates needed.
 	}
 
-	if config.ParsedGeneralConfig.Obmondo != nil && config.ParsedGeneralConfig.Obmondo.Monitoring {
+	if config.ObmondoIntegrationEnabled() {
 		embeddedTemplateNames = append(embeddedTemplateNames,
 			constants.ObmondoClientCertSecretTemplateNames...,
 		)


### PR DESCRIPTION
## Problem

`obmondo.monitoring: true` refused to validate unless an Obmondo-issued mTLS certificate and key were already on disk:

```
obmondo.monitoring is true but obmondo.certPath is empty,
an Obmondo-issued mTLS cert is required
```

But that flag asks for **kube-prometheus**, which is gated separately by `--skip-monitoring-setup` and `general.kubePrometheus` and is not an Obmondo feature. An opensource user who turned it on was rejected for lacking a credential only a paying customer can obtain.

## The gate

```go
func ObmondoIntegrationEnabled() bool {
	obmondo := ParsedGeneralConfig.Obmondo
	return obmondo != nil &&
		obmondo.Monitoring &&
		obmondo.CertPath != "" &&
		obmondo.KeyPath != ""
}
```

plus, once at validation:

```go
if _, err := cert.ReadCN(obmondo.CertPath); err != nil {
	return fmt.Errorf("obmondo.certPath is not a readable X.509 certificate: %w", err)
}
```

Monitoring requested, both paths set, and the certificate actually a certificate.

The X.509 parse lives at **validation**, not in the predicate: the predicate is called from four render paths and would re-read the file each time, and validation is where the operator is still looking at their config. A present-but-invalid certificate previously surfaced as a render failure, long after that point.

Five behaviours moved from `Obmondo.Monitoring` to this predicate:

| | |
| --- | --- |
| `templates.go:335` | client cert CN read into cluster-vars |
| `templates.go:691` | KubeAid Agent ArgoCD application |
| `templates.go:816` | `obmondo-clientcert` SealedSecret + `alertmanager-main` |
| `setup_cluster.go:95` | pre-creating the `monitoring` namespace those depend on |

## What this gate is, and is not

**It is not entitlement.** The API refuses to mint a Puppet certificate for a cluster with no active subscription — `ClusterHasActiveSubscription` answers `402` before `issuePuppetCertificate` runs — and rejects alerts from a cluster that has none. A lapsed subscription is already handled twice server-side, and a rendered alertmanager hook simply bounces.

**What it prevents** is rendering an `obmondo-clientcert` SealedSecret and an `alertmanager-main` secret out of empty paths, which fails the ArgoCD sync with an error pointing at sealed-secrets rather than at the operator's config.

That is why "are the paths set, and is the certificate real" is the right strength. It answers *do we have material to render* — the only question the renderer needs answered.

## Validation

| config | before | after |
| --- | --- | --- |
| `monitoring: true`, no certs | **rejected** | allowed — kube-prometheus, no Obmondo wiring |
| certPath without keyPath | rejected | rejected |
| keyPath without certPath | not caught | **rejected** |
| both set, path missing | rejected | rejected |
| both set, file is not a certificate | **not caught** | **rejected** |
| both present and valid | full integration | unchanged |

## Testing

Full `go test ./...` and `golangci-lint run ./...` green.

The X.509 check earned its place immediately: an existing case wrote `[]byte("c")` as a certificate and passed. It now mints a real self-signed cert, and there is a new negative case for a file that exists but is not one. Two cases that asserted the old cert-required behaviour were rewritten to the new intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)