### PR TITLE
docs: format MAINTAINERS.md as a table

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,9 +4,11 @@ This is the list of maintainers for KubeAid CLI.
 
 The current maintainers of the KubeAid CLI project are (in alphabetical order):
 
-* [Archisman Mridha](https://github.com/Archisman-Mridha) (Obmondo)
-* [Ashish Jaiswal](https://github.com/ashish1099) (Obmondo)
-* [Klavs Klavsen](https://github.com/KlavsKlavsen) (Obmondo)
-* [Rishi Mondal](https://github.com/MAVRICK-1) (Obmondo)
-* [Shubham Singh](https://github.com/1Shubham7) (Obmondo)
+| Maintainer | GitHub ID | Company/Organization |
+| ---------- | --------- | --------------------- |
+| Archisman Mridha | [@Archisman-Mridha](https://github.com/Archisman-Mridha) | Obmondo |
+| Ashish Jaiswal | [@ashish1099](https://github.com/ashish1099) | Obmondo |
+| Klavs Klavsen | [@KlavsKlavsen](https://github.com/KlavsKlavsen) | Obmondo |
+| Rishi Mondal | [@MAVRICK-1](https://github.com/MAVRICK-1) | Obmondo |
+| Shubham Singh | [@1Shubham7](https://github.com/1Shubham7) | Obmondo |
 


### PR DESCRIPTION
CNCF Sandbox application requires MAINTAINERS.md as a table with Name/GitHub ID/Company columns - our bullet-list format would auto-close the application.