### PR TITLE
feat(aws): add EKS (managed control plane) cluster support

### DIFF
--- a/cmd/kubeaid-core/root/cluster/recover.go
+++ b/cmd/kubeaid-core/root/cluster/recover.go
@@ -6,8 +6,10 @@ package cluster
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/Obmondo/kubeaid-cli/pkg/config"
 	"github.com/Obmondo/kubeaid-cli/pkg/constants"
 	"github.com/Obmondo/kubeaid-cli/pkg/core"
+	"github.com/Obmondo/kubeaid-cli/pkg/utils/assert"
 )
 
 var RecoverCmd = &cobra.Command{
@@ -16,6 +18,13 @@ var RecoverCmd = &cobra.Command{
 	Short: "Recover a KubeAid managed K8s cluster (from a disaster recovery backup)",
 
 	Run: func(cmd *cobra.Command, args []string) {
+		// EKS recovery isn't wired yet — recover re-runs the bootstrap and the
+		// Velero restore, and neither has been exercised against a managed
+		// control plane. Fail loudly instead of half-recovering.
+		assert.Assert(cmd.Context(), !config.EKSEnabled(),
+			"`cluster recover` doesn't support EKS clusters yet — re-bootstrap and restore from the Velero backup manually",
+		)
+
 		core.RecoverCluster(cmd.Context(),
 			managementClusterName,
 			skipPRWorkflow,

--- a/cmd/kubeaid-core/root/cluster/upgrade/upgrade.go
+++ b/cmd/kubeaid-core/root/cluster/upgrade/upgrade.go
@@ -38,6 +38,17 @@ var UpgradeCmd = &cobra.Command{
 			})
 
 		case constants.CloudProviderAWS:
+			// EKS clusters are upgraded the GitOps way : AWS owns the control
+			// plane and CAPA rolls it (plus the MachineDeployments) when the
+			// version in the capi-cluster values changes.
+			if config.EKSEnabled() {
+				assert.Assert(cmd.Context(), false,
+					"`cluster upgrade` doesn't apply to EKS clusters : bump global.kubernetes.version in "+
+						"argocd-apps/values-capi-cluster.yaml in your kubeaid-config repo and let ArgoCD sync — "+
+						"CAPA then upgrades the EKS control plane and rolls the node-groups",
+				)
+			}
+
 			core.UpgradeCluster(cmd.Context(), core.UpgradeClusterArgs{
 				SkipPRWorkflow: skipPRWorkflow,
 

--- a/docs/superpowers/specs/2026-08-09-eks-support-design.md
+++ b/docs/superpowers/specs/2026-08-09-eks-support-design.md
@@ -1,0 +1,201 @@
+# EKS Support in KubeAid CLI — Design
+
+**Date:** 2026-08-09
+**Status:** Implemented (2026-08-10) — see "Implementation notes" at the bottom for
+deltas discovered while building
+**Repos affected:** `Obmondo/kubeaid-cli`, `Obmondo/kubeaid` (the `capi-cluster` Helm chart)
+
+## Goal
+
+Let `kubeaid-cli` provision and manage **Amazon EKS** clusters (AWS-managed control
+plane) alongside the existing self-managed CAPA-based AWS clusters, using the same
+GitOps flow: throwaway K3D management cluster → Cluster API provisions the target →
+`clusterctl move` pivots → ArgoCD reconciles the KubeAid addon stack.
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | EKS is a **variant of the existing AWS provider**, not a sixth cloud provider | The infrastructure provider stays CAPA (`aws`); credentials, IAM stack, and DR are shared. A separate provider would duplicate all of it and break the `getInfrastructureProviderName()` == provider-name assumption. |
+| 2 | Workers are **self-managed `MachineDeployment`s attached to the EKS control plane** — not `AWSManagedMachinePool` | Upstream CAPA v2.11.1 classes EKS support as **Stable** but machine pools (incl. managed) as **experimental**. The stable path also reuses KubeAid's existing failure-domain MachineDeployment fan-out and CAPI-mode cluster-autoscaler. Managed machine pools can be added later when CAPA graduates them. |
+| 3 | Node bootstrap uses **`NodeadmConfigTemplate`** (AL2023); **EKS clusters require Kubernetes ≥ v1.33** | Upstream: `EKSConfig`/AL2 only supports k8s ≤ v1.32 and AL2 went EOL 2026-06-30. Single bootstrap provider keeps the surface small. |
+| 4 | Worker AMIs are resolved by CAPA via `ami.eksLookupType: AmazonLinux2023` | No AMI prompt or Canonical simplestreams lookup for EKS. `insecureSkipSecretsManager: true` is set on the machine template, as upstream requires for AL2023. |
+| 5 | **Cilium is the default (and only) CNI** on EKS clusters | Stack uniformity across all KubeAid clusters (network policy, Hubble). Implemented declaratively: `AWSManagedControlPlane.spec.vpcCni.disable: true` and `spec.kubeProxy.disable: true`; Cilium runs with kube-proxy replacement against the EKS endpoint on port 443. |
+| 6 | The prompt asks **self-managed vs EKS before credentials** | Credentials are identical either way (CAPA admin bootstrap key), but the questions after them differ: EKS has no HA/replica question (AWS runs the CP multi-AZ), no AMI question (decision 4), and no SSH key (workers stay keyless; Session Manager covers debugging). |
+| 7 | Lifecycle scope: **bootstrap + delete** for EKS. `cluster upgrade` is **KubeOne-only** going forward. `cluster recover` is **out of scope** for this design | Once pivoted, the cluster is self-managing: an upgrade is a GitOps edit (bump the version in `values-capi-cluster.yaml`; ArgoCD syncs; CAPA upgrades the EKS control plane and rolls the MachineDeployments). Recover is conceptually needed for *all* cloud providers but is not fully supported yet — deliberately deferred, not forgotten. |
+| 8 | **No IAM changes needed** | Because workers are MachineDeployments (decision 2), the default CAPA CloudFormation stack already contains everything EKS needs: CAPA's defaulter ships with `EKS.Disable: false`, so `eks-controlplane.cluster-api-provider-aws.sigs.k8s.io` (role) and `controllers-eks.…` (policy) exist in every stack kubeaid-cli creates today. Managed machine pools would have needed a custom `AWSIAMConfiguration`; we don't. |
+
+## Configuration surface
+
+### `general.yaml`
+
+```yaml
+cloud:
+  aws:
+    region: eu-west-1
+    eks: true            # NEW — selects the managed control plane
+    nodeGroups:          # unchanged shape
+      - name: primary
+        instanceType: m5.large
+        minSize: 3
+        maxSize: 9
+```
+
+Validation when `eks: true`:
+
+- `sshKeyName`, `controlPlane.*` (replicas, instanceType, ami, loadBalancerScheme)
+  are **rejected** with a clear error — they have no meaning on EKS.
+- Kubernetes version must be ≥ v1.33 (decision 3), on top of the existing
+  released/non-EOL checks.
+
+`secrets.yaml` is unchanged: same admin access key ID / secret / optional session
+token, exported the same way, feeding the same embedded clusterawsadm calls.
+
+### Prompt flow (`pkg/config/prompt/provider_aws.go`)
+
+```
+provider = AWS
+  → NEW select: "Control plane: self-managed (EC2) / EKS (managed by AWS)"
+  → credentials form                     (unchanged)
+  → [self-managed] HA confirm → AMI discovery → SSH key derivation   (unchanged)
+  → [EKS]          nothing — straight to node groups
+```
+
+The select writes a new `PromptedConfig` field (e.g. `AWSEKS bool`) consumed by
+`pkg/render/templates/general.yaml.tmpl`, which gains an EKS branch. `postProcess`
+(SSH-key derivation) is skipped for EKS.
+
+## Provisioning flow changes (kubeaid-cli)
+
+Everything below is a delta on `provisionMainClusterUsingClusterAPI`; the K3D
+management cluster, ArgoCD install, kubeaid-config templating, PR-merge gate, and
+`clusterctl move` pivot are untouched.
+
+1. **CAPI providers** — `values-cluster-api-operator.yaml.tmpl` currently
+   hard-codes `bootstrap: kubeadm` / `controlPlane: kubeadm`. When EKS: also
+   declare the `eks` **bootstrap** and **control-plane** providers (CAPA ships
+   them as separate operator components). The kubeadm providers remain — the K3D
+   management cluster itself needs nothing new, and `clusterctl move` back out
+   (delete path) requires the same providers in the management cluster.
+2. **Addon set** (`pkg/constants/templates.go` selection in
+   `getEmbeddedNonSecretTemplateNames`):
+   - drop `ccm-aws` — the EKS control plane runs the AWS cloud controller;
+   - keep `cluster-autoscaler` — CAPI mode works unchanged against
+     MachineDeployments;
+   - keep `external-snapshotter`;
+   - Cilium values gain an EKS branch: `k8sServicePort: 443` and the
+     `AWSManagedControlPlane` endpoint host instead of `6443`/KCP endpoint.
+     The initial Cilium install cannot ride the KubeadmControlPlane postKubeadm
+     hook (there is no KCP) — it is installed the same way but triggered after
+     the control plane reports ready.
+3. **Control-plane gates** — skip `WaitForControlPlaneRolloutComplete`'s KCP
+   summary (it already degrades gracefully on missing KCP) and skip
+   `RemoveNoScheduleTaintsFromMasterNodes` (no control-plane nodes exist).
+4. **Pivot** — the pre-pivot CAPA credential-zeroing and rollout applies
+   unchanged; `clusterctl move` supports managed control planes.
+5. **Guards** — `cluster upgrade` (any CAPI provider) and `cluster recover`
+   (EKS) exit with a message pointing at the GitOps flow / roadmap
+   respectively.
+
+## Chart changes (KubeAid repo, `argocd-helm-charts/capi-cluster`)
+
+Behind a new `aws.eks` values flag in `charts/aws/`:
+
+- **`AWSManagedControlPlane`** template: version, region, network,
+  `bastion.enabled`, `vpcCni.disable: true`, `kubeProxy.disable: true`,
+  endpoint access config. The `Cluster` template's `controlPlaneRef` switches
+  to it when `eks` is set; `AWSCluster` + `KubeadmControlPlane` +
+  `KubeadmConfigTemplate` render only when it is not.
+- **`NodeadmConfigTemplate`** template; the existing `MachineDeployment`
+  failure-domain fan-out is reused with its bootstrap `configRef` switched to
+  it, and `AWSMachineTemplate` gains the EKS branch:
+  `ami.eksLookupType: AmazonLinux2023`, `insecureSkipSecretsManager: true`,
+  no `sshKeyName`.
+- **`provider-aws.yaml`**: add `EKS: true` (and `EKSEnableIAM` if needed) to
+  `featureGates`, following the existing `MachinePool` gate pattern.
+- Chart unit tests for the EKS rendering path, mirroring
+  `charts/hetzner/tests/`.
+
+## Error handling
+
+- Config validation failures (CP fields with `eks: true`, version < v1.33) fail
+  `config generate` / `cluster bootstrap` fast, before any AWS call.
+- `cluster upgrade` / `cluster recover` on an EKS cluster: clear, actionable
+  error (what to edit in the kubeaid-config repo for upgrades; recover roadmap
+  pointer) — never a silent no-op.
+- Bootstrap waits: control-plane readiness is judged from
+  `AWSManagedControlPlane` status conditions instead of KCP rollout state.
+
+## Testing
+
+- **kubeaid-cli**: golden tests for the new prompt branch and `general.yaml`
+  rendering (`pkg/render/render_golden_test.go`,
+  `pkg/config/prompt/render_hybrid_test.go`, `e2e/prompt/prompt_test.go`);
+  unit tests for the new validation rules and addon-set selection.
+- **KubeAid chart**: `helm unittest` cases for EKS on/off rendering.
+- **End-to-end**: a real EKS bootstrap + delete against a test AWS account,
+  exercised manually first; CI automation is follow-up work.
+
+## Out of scope (deliberate)
+
+- `AWSManagedMachinePool` (EKS managed node groups) and Fargate — experimental
+  upstream; revisit when CAPA graduates them.
+- `cluster recover` for EKS — recover needs a design of its own covering all
+  cloud providers; today it is not fully supported anywhere.
+- IRSA / Pod Identity for workload IAM (kube2iam replacement) — tracked
+  separately; DR on EKS inherits whatever that effort decides.
+- Reusing an existing VPC (`vpcID`) with EKS — parity item; verify CAPA
+  `AWSManagedControlPlane` network-spec support during implementation and gate
+  accordingly.
+
+## Open items to resolve during implementation
+
+1. **EBS CSI driver**: EKS does not install a storage driver by default. The
+   KubeAid repo already carries `argocd-helm-charts/aws-ebs-csi-driver`; add it
+   to the EKS addon set in kubeaid-cli (a values template + registration in
+   `pkg/constants/templates.go` — the CLI does not template it for self-managed
+   AWS today either). Settle where its IAM permissions come from (node instance
+   profile vs IRSA) during implementation.
+2. **Cilium initial install trigger**: exact hook point replacing the KCP
+   postKubeadm hook (control-plane-ready wait vs ArgoCD sync wave).
+3. **`EKSEnableIAM` feature gate**: whether CAPA needs it for our resource
+   shapes, or `EKS: true` alone suffices.
+
+## Implementation notes (deltas from the design above)
+
+- **No cluster-api-operator changes were needed.** Since CAPA v2 the EKS
+  bootstrap and control-plane providers are merged into the main AWS provider
+  and EKS support is enabled by default ("Support for EKS is enabled by
+  default when you use the AWS infrastructure provider" — CAPA
+  eks/enabling.md). The chart still sets `EKS: true` explicitly on the
+  `InfrastructureProvider` feature gates, as insurance against a future
+  default flip.
+- **No IAM changes were needed**, as predicted by decision 8.
+- **Initial Cilium install**: kubeaid-cli installs the KubeAid cilium chart
+  into the EKS cluster itself (`installCiliumOnEKSCluster`,
+  `pkg/core/bootstrap_cluster.go`) via the same Helm machinery used for
+  ArgoCD, with `k8sServiceHost`/`k8sServicePort` taken from the cluster
+  kubeconfig — replacing the KubeadmControlPlane postKubeadm hook. The cilium
+  ArgoCD App adopts the manifests afterwards.
+- **Pre-pivot CAPA credential zeroing is skipped for EKS**: post-pivot CAPA
+  runs on workers whose `nodes.…` instance profile lacks the controllers
+  policy, so CAPA keeps using the cloud-credentials Secret (IRSA later). For
+  the same reason the chart drops the control-plane nodeSelector on the CAPA
+  deployment when `aws.eks` is set.
+- **`cluster upgrade` is now KubeOne-oriented**: the AWS path errors out for
+  EKS clusters, pointing at the GitOps flow (bump
+  `global.kubernetes.version` in `values-capi-cluster.yaml`). `cluster
+  recover` errors out for EKS clusters.
+- **values-cilium.yaml now renders the endpoint port from the kubeconfig**
+  (`ControlPlaneEndpointPort`, default 6443 — EKS yields 443) instead of a
+  hard-coded 6443.
+- **KubeAid chart**: `capi-cluster/charts/aws` gained `eks` values flag,
+  `AWSManagedControlPlane` + `AWSManagedCluster` + `NodeadmConfigTemplate`
+  templates, EKS branches in `AWSMachineTemplate`/`MachineDeployment`,
+  kubeadm resources gated off, `MachineHealthCheck` (control-plane-scoped)
+  gated off, machine pools excluded for EKS, plus
+  `values.example.eks.yaml` and a helm-unittest suite
+  (`charts/aws/tests/eks_test.yaml`, 10 tests, passing).
+- **Deployed CAPA version caveat**: the chart's `global.capa.version` default
+  is v2.9.2; NodeadmConfig needs a newer CAPA — bump to >= v2.11 when
+  enabling EKS.

--- a/e2e/prompt/prompt_test.go
+++ b/e2e/prompt/prompt_test.go
@@ -310,7 +310,12 @@ func TestAWS_PromptFlow(t *testing.T) {
 	c.expectString("service-user token")
 	c.sendLine("nbp_e2etoken")
 
-	// Step 3 — AWS credentials form.
+	// Step 3 — control-plane flavour select (before credentials). Default is
+	// the first option: self-managed.
+	c.expectString("Control plane:")
+	c.acceptDefault()
+
+	// AWS credentials form.
 	// HOME is set to a scratch dir in newConsole so ~/.aws is empty.
 	c.expectString("Access Key ID:")
 	c.sendLine("aws-access-key")

--- a/pkg/config/general.go
+++ b/pkg/config/general.go
@@ -437,10 +437,19 @@ type (
 	AWSConfig struct {
 		Region string `yaml:"region" validate:"notblank"`
 
-		SSHKeyName     string                     `yaml:"sshKeyName"     validate:"notblank"`
+		// EKS flips the cluster to an AWS managed (EKS) control plane,
+		// provisioned via CAPA's AWSManagedControlPlane. Workers stay
+		// self-managed MachineDeployments (CAPA's stable EKS worker
+		// path), bootstrapped with NodeadmConfig on AL2023 AMIs that
+		// CAPA resolves itself — so sshKeyName, controlPlane and
+		// per-node-group AMIs must be left unset. Cross-field rules
+		// live in pkg/config/parser/validate.go (validateAWSConfig).
+		EKS bool `yaml:"eks"`
+
+		SSHKeyName     string                     `yaml:"sshKeyName"`
 		VPCID          *string                    `yaml:"vpcID"`
-		BastionEnabled bool                       `yaml:"bastionEnabled"                     default:"True"`
-		ControlPlane   AWSControlPlane            `yaml:"controlPlane"   validate:"required"`
+		BastionEnabled bool                       `yaml:"bastionEnabled" default:"True"`
+		ControlPlane   *AWSControlPlane           `yaml:"controlPlane,omitempty"`
 		NodeGroups     []AWSAutoScalableNodeGroup `yaml:"nodeGroups"`
 	}
 
@@ -454,10 +463,10 @@ type (
 	AWSAutoScalableNodeGroup struct {
 		AutoScalableNodeGroup `yaml:",inline"`
 
-		AMI            AMIConfig `yaml:"ami"            validate:"required"`
-		InstanceType   string    `yaml:"instanceType"   validate:"notblank"`
-		RootVolumeSize uint32    `yaml:"rootVolumeSize" validate:"required"`
-		SSHKeyName     string    `yaml:"sshKeyName"     validate:"notblank"`
+		AMI            *AMIConfig `yaml:"ami,omitempty"`
+		InstanceType   string     `yaml:"instanceType"   validate:"notblank"`
+		RootVolumeSize uint32     `yaml:"rootVolumeSize" validate:"required"`
+		SSHKeyName     string     `yaml:"sshKeyName,omitempty"`
 	}
 
 	AMIConfig struct {

--- a/pkg/config/parser/validate.go
+++ b/pkg/config/parser/validate.go
@@ -401,11 +401,95 @@ func validateAWSConfig() error {
 	}
 
 	awsConfig := config.ParsedGeneralConfig.Cloud.AWS
+
+	if awsConfig.EKS {
+		if err := validateAWSEKSConfig(awsConfig); err != nil {
+			return err
+		}
+	} else if err := validateAWSSelfManagedConfig(awsConfig); err != nil {
+		return err
+	}
+
 	for _, awsAutoScalableNodeGroup := range awsConfig.NodeGroups {
 		if err := validateAutoScalableNodeGroup(
 			&awsAutoScalableNodeGroup.AutoScalableNodeGroup,
 		); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+// validateAWSEKSConfig enforces the cross-field rules of an EKS cluster : AWS
+// owns the control plane (multi-AZ by design, no replicas / instance type /
+// AMI to pick), worker AMIs are resolved by CAPA via
+// ami.eksLookupType: AmazonLinux2023, and workers stay keyless (use SSM
+// Session Manager for debugging). AL2023 node bootstrapping (NodeadmConfig)
+// requires Kubernetes >= v1.33 — AL2 / EKSConfig is EOL upstream.
+func validateAWSEKSConfig(awsConfig *config.AWSConfig) error {
+	if awsConfig.ControlPlane != nil {
+		return errors.New(
+			"cloud.aws.controlPlane must not be set when cloud.aws.eks is true — AWS manages the EKS control plane",
+		)
+	}
+	if awsConfig.SSHKeyName != "" {
+		return errors.New(
+			"cloud.aws.sshKeyName must not be set when cloud.aws.eks is true — EKS workers stay keyless (use SSM Session Manager for node access)",
+		)
+	}
+	for _, nodeGroup := range awsConfig.NodeGroups {
+		if nodeGroup.AMI != nil {
+			return fmt.Errorf(
+				"cloud.aws.nodeGroups[%s].ami must not be set when cloud.aws.eks is true — CAPA resolves the EKS optimized AL2023 AMI itself",
+				nodeGroup.Name,
+			)
+		}
+		if nodeGroup.SSHKeyName != "" {
+			return fmt.Errorf(
+				"cloud.aws.nodeGroups[%s].sshKeyName must not be set when cloud.aws.eks is true — EKS workers stay keyless",
+				nodeGroup.Name,
+			)
+		}
+	}
+	if len(awsConfig.NodeGroups) == 0 {
+		return errors.New(
+			"at least one node-group is required when cloud.aws.eks is true — an EKS cluster has no control-plane nodes to schedule workloads on",
+		)
+	}
+
+	parsedK8sVersion, err := version.ParseSemantic(config.ParsedGeneralConfig.Cluster.K8sVersion)
+	if err != nil {
+		return fmt.Errorf("parsing K8s semantic version: %w", err)
+	}
+	parsedMin, err := version.ParseMajorMinor(constants.MinEKSSupportedK8sVersion)
+	if err != nil {
+		return fmt.Errorf("parsing min EKS supported K8s version: %w", err)
+	}
+	if !parsedK8sVersion.AtLeast(parsedMin) {
+		return fmt.Errorf(
+			"K8s version must be >= %s for EKS clusters — node bootstrapping uses NodeadmConfig on AL2023 AMIs, and AL2 (K8s <= v1.32) is EOL",
+			constants.MinEKSSupportedK8sVersion,
+		)
+	}
+	return nil
+}
+
+// validateAWSSelfManagedConfig enforces the fields a kubeadm based (self
+// managed control plane) AWS cluster needs — previously struct-tag enforced,
+// moved here because they must stay unset for EKS.
+func validateAWSSelfManagedConfig(awsConfig *config.AWSConfig) error {
+	if awsConfig.ControlPlane == nil {
+		return errors.New("cloud.aws.controlPlane is required (unless cloud.aws.eks is true)")
+	}
+	if awsConfig.SSHKeyName == "" {
+		return errors.New("cloud.aws.sshKeyName is required (unless cloud.aws.eks is true)")
+	}
+	for _, nodeGroup := range awsConfig.NodeGroups {
+		if nodeGroup.AMI == nil || nodeGroup.AMI.ID == "" {
+			return fmt.Errorf("cloud.aws.nodeGroups[%s].ami.id is required (unless cloud.aws.eks is true)", nodeGroup.Name)
+		}
+		if nodeGroup.SSHKeyName == "" {
+			return fmt.Errorf("cloud.aws.nodeGroups[%s].sshKeyName is required (unless cloud.aws.eks is true)", nodeGroup.Name)
 		}
 	}
 	return nil

--- a/pkg/config/parser/validate_test.go
+++ b/pkg/config/parser/validate_test.go
@@ -613,7 +613,83 @@ func TestValidateAWSConfig(t *testing.T) {
 		{
 			name:    "AWS credentials with no node-groups passes",
 			secrets: &config.SecretsConfig{AWS: &config.AWSCredentials{}},
-			general: &config.GeneralConfig{Cloud: config.CloudConfig{AWS: &config.AWSConfig{}}},
+			general: &config.GeneralConfig{Cloud: config.CloudConfig{AWS: &config.AWSConfig{
+				SSHKeyName:   "deploy-key",
+				ControlPlane: &config.AWSControlPlane{AMI: config.AMIConfig{ID: "ami-123"}},
+			}}},
+		},
+		{
+			name:       "self-managed without controlPlane is rejected",
+			secrets:    &config.SecretsConfig{AWS: &config.AWSCredentials{}},
+			general:    &config.GeneralConfig{Cloud: config.CloudConfig{AWS: &config.AWSConfig{}}},
+			wantErr:    true,
+			wantErrSub: "cloud.aws.controlPlane is required",
+		},
+		{
+			name:    "EKS with a node-group passes",
+			secrets: &config.SecretsConfig{AWS: &config.AWSCredentials{}},
+			general: &config.GeneralConfig{
+				Cluster: config.ClusterConfig{K8sVersion: "v1.34.0"},
+				Cloud: config.CloudConfig{AWS: &config.AWSConfig{
+					EKS: true,
+					NodeGroups: []config.AWSAutoScalableNodeGroup{
+						{InstanceType: "m5.large"},
+					},
+				}},
+			},
+		},
+		{
+			name:    "EKS with controlPlane set is rejected",
+			secrets: &config.SecretsConfig{AWS: &config.AWSCredentials{}},
+			general: &config.GeneralConfig{
+				Cluster: config.ClusterConfig{K8sVersion: "v1.34.0"},
+				Cloud: config.CloudConfig{AWS: &config.AWSConfig{
+					EKS:          true,
+					ControlPlane: &config.AWSControlPlane{},
+				}},
+			},
+			wantErr:    true,
+			wantErrSub: "cloud.aws.controlPlane must not be set",
+		},
+		{
+			name:    "EKS with a node-group AMI is rejected",
+			secrets: &config.SecretsConfig{AWS: &config.AWSCredentials{}},
+			general: &config.GeneralConfig{
+				Cluster: config.ClusterConfig{K8sVersion: "v1.34.0"},
+				Cloud: config.CloudConfig{AWS: &config.AWSConfig{
+					EKS: true,
+					NodeGroups: []config.AWSAutoScalableNodeGroup{
+						{InstanceType: "m5.large", AMI: &config.AMIConfig{ID: "ami-123"}},
+					},
+				}},
+			},
+			wantErr:    true,
+			wantErrSub: "ami must not be set",
+		},
+		{
+			name:    "EKS without node-groups is rejected",
+			secrets: &config.SecretsConfig{AWS: &config.AWSCredentials{}},
+			general: &config.GeneralConfig{
+				Cluster: config.ClusterConfig{K8sVersion: "v1.34.0"},
+				Cloud:   config.CloudConfig{AWS: &config.AWSConfig{EKS: true}},
+			},
+			wantErr:    true,
+			wantErrSub: "at least one node-group is required",
+		},
+		{
+			name:    "EKS below v1.33 is rejected",
+			secrets: &config.SecretsConfig{AWS: &config.AWSCredentials{}},
+			general: &config.GeneralConfig{
+				Cluster: config.ClusterConfig{K8sVersion: "v1.32.0"},
+				Cloud: config.CloudConfig{AWS: &config.AWSConfig{
+					EKS: true,
+					NodeGroups: []config.AWSAutoScalableNodeGroup{
+						{InstanceType: "m5.large"},
+					},
+				}},
+			},
+			wantErr:    true,
+			wantErrSub: "K8s version must be >= v1.33 for EKS",
 		},
 	}, validateAWSConfig)
 }

--- a/pkg/config/predicates.go
+++ b/pkg/config/predicates.go
@@ -17,6 +17,13 @@ type ReleaseDetails struct {
 	TagName string `json:"tag_name"`
 }
 
+// EKSEnabled reports whether the cluster runs an AWS managed (EKS) control
+// plane — CAPA AWSManagedControlPlane instead of KubeadmControlPlane. Workers
+// remain self-managed MachineDeployments either way.
+func EKSEnabled() bool {
+	return ParsedGeneralConfig.Cloud.AWS != nil && ParsedGeneralConfig.Cloud.AWS.EKS
+}
+
 // Returns whether we're using HCloud.
 func UsingHCloud() bool {
 	if ParsedGeneralConfig.Cloud.Hetzner == nil {

--- a/pkg/config/prompt/provider_aws.go
+++ b/pkg/config/prompt/provider_aws.go
@@ -140,6 +140,12 @@ func newAWSProvider() *awsPrompter {
 }
 
 func (p *awsPrompter) SummaryLines(cfg *PromptedConfig) []string {
+	if cfg.AWSEKS {
+		return []string{
+			fmt.Sprintf("  Region:        %s", cfg.AWSRegion),
+			"  Control plane: EKS (managed by AWS)",
+		}
+	}
 	return []string{
 		fmt.Sprintf("  Region:        %s", cfg.AWSRegion),
 		fmt.Sprintf("  Instance type: %s", cfg.AWSCPInstanceType),
@@ -176,6 +182,24 @@ func (p *awsPrompter) RunCredentialsForm(cfg *PromptedConfig, _ *autoDetectedCon
 		cfg.AWSCPInstanceType = "t3.medium"
 	}
 
+	// Control-plane flavour comes BEFORE credentials : the credentials are the
+	// same either way, but every question after them differs — EKS has no HA /
+	// replica choice (AWS runs the control plane multi-AZ), no AMI (CAPA
+	// resolves the EKS optimized AL2023 image itself) and no SSH key name.
+	if err := huh.NewForm(
+		huh.NewGroup(
+			huh.NewSelect[bool]().
+				Title("Control plane:").
+				Options(
+					huh.NewOption("Self-managed (EC2, kubeadm)", false),
+					huh.NewOption("EKS (managed by AWS)", true),
+				).
+				Value(&cfg.AWSEKS),
+		).Title("AWS control plane").Description("Step 3/4"),
+	).Run(); err != nil {
+		return err
+	}
+
 	haChoice := cfg.AWSCPReplicas != "1"
 
 	credGroup := huh.NewGroup(
@@ -201,16 +225,27 @@ func (p *awsPrompter) RunCredentialsForm(cfg *PromptedConfig, _ *autoDetectedCon
 		slog.Info("No AWS credentials found in ~/.aws — prompting")
 	}
 
+	haGroup := huh.NewGroup(
+		huh.NewConfirm().
+			Title("Enable high availability for the control plane?").
+			Value(&haChoice),
+	).WithHideFunc(func() bool {
+		// EKS control planes are HA by design — nothing to ask.
+		return cfg.AWSEKS
+	})
+
 	err := huh.NewForm(
 		credGroup,
-		huh.NewGroup(
-			huh.NewConfirm().
-				Title("Enable high availability for the control plane?").
-				Value(&haChoice),
-		).Title("AWS credentials").Description("Step 3/4"),
+		haGroup.Title("AWS credentials").Description("Step 3/4 (cont.)"),
 	).Run()
 	if err != nil {
 		return err
+	}
+
+	if cfg.AWSEKS {
+		// AWS owns the control plane and CAPA resolves worker AMIs — nothing
+		// more to collect.
+		return nil
 	}
 
 	if haChoice {
@@ -252,7 +287,13 @@ func (p *awsPrompter) RunCredentialsForm(cfg *PromptedConfig, _ *autoDetectedCon
 
 // postProcess derives AWSSSHKeyName after the Git/SSH step has populated the key path.
 // Called by ConfigFromPrompt after runGitSSHForm.
+// EKS clusters skip it : workers stay keyless (SSM Session Manager covers
+// debugging) and the rendered config must not carry an sshKeyName.
 func (p *awsPrompter) postProcess(cfg *PromptedConfig) {
+	if cfg.AWSEKS {
+		return
+	}
+
 	keyPath := cfg.KubeaidConfigDeployKeyPath
 	if keyPath == "" {
 		keyPath = cfg.SSHKeyPath

--- a/pkg/config/prompt/resume.go
+++ b/pkg/config/prompt/resume.go
@@ -217,10 +217,13 @@ func applyCloudConfigToPromptedConfig(cloud *config.CloudConfig, cfg *PromptedCo
 	case cloud.AWS != nil:
 		cfg.CloudProvider = constants.CloudProviderAWS
 		cfg.AWSRegion = firstNonEmpty(cloud.AWS.Region, cfg.AWSRegion)
+		cfg.AWSEKS = cfg.AWSEKS || cloud.AWS.EKS
 		cfg.AWSSSHKeyName = firstNonEmpty(cloud.AWS.SSHKeyName, cfg.AWSSSHKeyName)
-		cfg.AWSCPInstanceType = firstNonEmpty(cloud.AWS.ControlPlane.InstanceType, cfg.AWSCPInstanceType)
-		cfg.AWSCPReplicas = firstNonEmpty(uint32String(cloud.AWS.ControlPlane.Replicas), cfg.AWSCPReplicas)
-		cfg.AWSAMIID = firstNonEmpty(cloud.AWS.ControlPlane.AMI.ID, cfg.AWSAMIID)
+		if cloud.AWS.ControlPlane != nil {
+			cfg.AWSCPInstanceType = firstNonEmpty(cloud.AWS.ControlPlane.InstanceType, cfg.AWSCPInstanceType)
+			cfg.AWSCPReplicas = firstNonEmpty(uint32String(cloud.AWS.ControlPlane.Replicas), cfg.AWSCPReplicas)
+			cfg.AWSAMIID = firstNonEmpty(cloud.AWS.ControlPlane.AMI.ID, cfg.AWSAMIID)
+		}
 	case cloud.Azure != nil:
 		cfg.CloudProvider = constants.CloudProviderAzure
 		cfg.AzureTenantID = firstNonEmpty(cloud.Azure.TenantID, cfg.AzureTenantID)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -522,6 +522,12 @@ const (
 	// NOTE : We need update this range manually, when upgrading KubeOne.
 	MinKubeOneSupportedK8sVersion = "v1.33"
 	MaxKubeOneSupportedK8sVersion = "v1.35"
+
+	// EKS clusters bootstrap their (self-managed MachineDeployment) workers
+	// with CAPA's NodeadmConfig on AL2023 AMIs, which upstream supports for
+	// K8s >= v1.33 only. AL2 / EKSConfig (K8s <= v1.32) went EOL 2026-06-30.
+	// REFER : CAPA docs/book/src/topics/eks/creating-a-cluster.md.
+	MinEKSSupportedK8sVersion = "v1.33"
 )
 
 // Kubernetes -> KubePrometheus compatibility matrix.

--- a/pkg/constants/templates.go
+++ b/pkg/constants/templates.go
@@ -71,6 +71,23 @@ var (
 		"argocd-apps/templates/external-snapshotter.yaml.tmpl",
 	}
 
+	// EKS clusters : the EKS control plane runs the AWS cloud controller, so
+	// ccm-aws is dropped. EKS installs no storage driver by default, so the
+	// EBS CSI driver is added instead. Cluster Autoscaler keeps working in
+	// CAPI mode against the (self-managed) MachineDeployments.
+	AWSEKSSpecificNonSecretTemplateNames = []string{
+		// For Cluster Autoscaler.
+		"argocd-apps/templates/cluster-autoscaler.yaml.tmpl",
+		"argocd-apps/values-cluster-autoscaler.yaml.tmpl",
+
+		// For External Snapshotter.
+		"argocd-apps/templates/external-snapshotter.yaml.tmpl",
+
+		// For the EBS CSI driver.
+		"argocd-apps/templates/aws-ebs-csi-driver.yaml.tmpl",
+		"argocd-apps/values-aws-ebs-csi-driver.yaml.tmpl",
+	}
+
 	AWSSpecificSecretTemplateNames = []string{
 		// For Cluster API.
 		"sealed-secrets/capi-cluster/cloud-credentials.yaml.tmpl",

--- a/pkg/core/bootstrap_cluster.go
+++ b/pkg/core/bootstrap_cluster.go
@@ -13,6 +13,7 @@ import (
 
 	argoCDV1Alpha1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/go-git/go-git/v5/plumbing/transport"
+	helmValues "helm.sh/helm/v3/pkg/cli/values"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/cmd/clusterawsadm/controller/credentials"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/cmd/clusterawsadm/controller/rollout"
@@ -373,11 +374,25 @@ func provisionAndSetupMainCluster(ctx context.Context, args ProvisionAndSetupMai
 	// ContainerCreating. Failing fast here points the operator at the
 	// actual problem (CNI not Ready on the CP Node).
 	bar := progress.FromCtx(ctx)
-	releaseNet := bar.InProgress("Waiting for control-plane Node networking to be ready")
-	err = kubernetes.WaitForCPNodesNetworkingReady(ctx, provisionedClusterClient)
-	releaseNet()
-	assert.AssertErrNil(ctx, err, "Failed waiting for control-plane Node networking to be ready")
-	bar.Substep("Control-plane Node networking ready")
+	switch {
+	// EKS clusters have no control-plane Nodes to check, and no
+	// KubeadmControlPlane postKubeadm hook to install the CNI : AWS's default
+	// VPC CNI and kube-proxy are disabled declaratively (AWSManagedControlPlane
+	// spec), so kubeaid-cli installs Cilium itself — the worker Nodes stay
+	// NotReady until it lands. The cilium ArgoCD App adopts these manifests
+	// once the main cluster's ArgoCD is up.
+	case config.EKSEnabled():
+		releaseCNI := bar.InProgress("Installing Cilium on the EKS cluster")
+		installCiliumOnEKSCluster(ctx)
+		releaseCNI()
+		bar.Substep("Installed Cilium on the EKS cluster")
+	default:
+		releaseNet := bar.InProgress("Waiting for control-plane Node networking to be ready")
+		err = kubernetes.WaitForCPNodesNetworkingReady(ctx, provisionedClusterClient)
+		releaseNet()
+		assert.AssertErrNil(ctx, err, "Failed waiting for control-plane Node networking to be ready")
+		bar.Substep("Control-plane Node networking ready")
+	}
 	bar.Substep("Main cluster provisioned 🎉")
 
 	// Ensure that application workloads can be scheduled.
@@ -557,7 +572,12 @@ func pivotCluster(ctx context.Context, mainClusterClient client.Client) {
 	//
 	// NOTE : The ClusterAPI AWS InfrastructureProvider component (CAPA controller) needs to run in
 	//        a master node.
-	if globals.CloudProviderName == constants.CloudProviderAWS {
+	//
+	// EKS clusters skip this : there are no control-plane nodes, so post-pivot
+	// CAPA runs on workers, whose nodes.cluster-api-provider-aws.sigs.k8s.io
+	// instance profile lacks the controllers policy. CAPA keeps using the
+	// cloud-credentials Secret instead (IRSA is the eventual replacement).
+	if globals.CloudProviderName == constants.CloudProviderAWS && !config.EKSEnabled() {
 		// Zero the credentials CAPA controller started with.
 		// This will force the CAPA controller to fall back to use the attached instance profiles.
 		err := credentials.ZeroCredentials(credentials.ZeroCredentialsInput{
@@ -613,6 +633,37 @@ func pivotCluster(ctx context.Context, mainClusterClient client.Client) {
 	assert.AssertErrNil(ctx, err, "Failed pivoting the cluster by executing 'clusterctl move'")
 	slog.InfoContext(ctx, "Pivoted the cluster by executing 'clusterctl move'")
 	bar.Substep("Pivoted ClusterAPI to main cluster")
+}
+
+// installCiliumOnEKSCluster installs Cilium into the just-provisioned EKS
+// cluster, mirroring what the KubeadmControlPlane postKubeadm hook does on
+// self-managed clusters (helm-render the KubeAid cilium chart with the
+// apiserver endpoint set). EKS has no control-plane nodes to run that hook,
+// and its AWS-default CNI + kube-proxy are disabled via AWSManagedControlPlane
+// (spec.vpcCni.disable / spec.kubeProxy.disable) — so without this install the
+// worker Nodes never turn Ready and nothing else can be scheduled. The cilium
+// ArgoCD App later adopts the same manifests (same chart, same values source).
+func installCiliumOnEKSCluster(ctx context.Context) {
+	endpoint, err := kubernetes.GetMainClusterEndpoint(ctx)
+	assert.AssertErrNil(ctx, err, "Failed getting main cluster endpoint")
+	assert.AssertNotNil(ctx, endpoint, "Main cluster kubeconfig has no endpoint — cannot install Cilium")
+
+	// KUBECONFIG already points at the main cluster's kubeconfig here — the
+	// Helm SDK picks it up from the environment.
+	err = kubernetes.HelmInstallOrUpgrade(ctx, &kubernetes.HelmInstallArgs{
+		ChartPath: path.Join(utils.GetKubeAidDir(), "argocd-helm-charts/cilium"),
+
+		Namespace:   "cilium",
+		ReleaseName: "cilium",
+		Values: &helmValues.Options{
+			Values: []string{
+				"cilium.kubeProxyReplacement=true",
+				fmt.Sprintf("cilium.k8sServiceHost=%s", endpoint.Hostname()),
+				fmt.Sprintf("cilium.k8sServicePort=%s", endpoint.Port()),
+			},
+		},
+	})
+	assert.AssertErrNil(ctx, err, "Failed installing Cilium on the EKS cluster")
 }
 
 func provisionMainClusterUsingKubeOne(ctx context.Context) {

--- a/pkg/core/templates.go
+++ b/pkg/core/templates.go
@@ -80,6 +80,12 @@ type TemplateValues struct {
 	*/
 	ControlPlaneEndpoint string
 
+	// ControlPlaneEndpointPort is the apiserver port Cilium's kube-proxy
+	// replacement dials. Kubeadm based clusters listen on 6443; EKS control
+	// planes listen on 443. Populated from the main cluster kubeconfig once
+	// the cluster exists, "6443" otherwise.
+	ControlPlaneEndpointPort string
+
 	// ControlPlaneLBPrivateIP and ControlPlaneLBBootstrapPublicIP
 	// are the HCloud load-balancer's private (steady-state) and
 	// bootstrap-only public IPs. Populated only on HCloud-VPN
@@ -481,7 +487,14 @@ func getTemplateValues(ctx context.Context) *TemplateValues {
 		assert.AssertErrNil(ctx, endpointErr, "Failed getting main cluster endpoint")
 		if endpoint != nil {
 			templateValues.ControlPlaneEndpoint = endpoint.Hostname()
+			templateValues.ControlPlaneEndpointPort = endpoint.Port()
 		}
+	}
+
+	// Kubeadm based control planes listen on 6443; the port only differs when
+	// the kubeconfig says so (EKS : 443).
+	if templateValues.ControlPlaneEndpointPort == "" {
+		templateValues.ControlPlaneEndpointPort = "6443"
 	}
 
 	return templateValues
@@ -542,9 +555,11 @@ func getEmbeddedNonSecretTemplateNames() []string {
 	// Add cloud provider specific templates.
 	switch globals.CloudProviderName {
 	case constants.CloudProviderAWS:
-		embeddedTemplateNames = append(embeddedTemplateNames,
-			constants.AWSSpecificNonSecretTemplateNames...,
-		)
+		awsTemplateNames := constants.AWSSpecificNonSecretTemplateNames
+		if config.EKSEnabled() {
+			awsTemplateNames = constants.AWSEKSSpecificNonSecretTemplateNames
+		}
+		embeddedTemplateNames = append(embeddedTemplateNames, awsTemplateNames...)
 
 		// Add Disaster Recovery related templates, if the user wants disaster recovery.
 		if config.ParsedGeneralConfig.Cloud.DisasterRecovery != nil {

--- a/pkg/core/templates/argocd-apps/templates/aws-ebs-csi-driver.yaml.tmpl
+++ b/pkg/core/templates/argocd-apps/templates/aws-ebs-csi-driver.yaml.tmpl
@@ -1,0 +1,28 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  labels:
+    kubeaid.io/version: {{ .KubeaidFork.Version }}
+    kubeaid.io/managed-by: kubeaid
+    kubeaid.io/sync-order: "10"
+  name: aws-ebs-csi-driver
+  namespace: argocd
+spec:
+  destination:
+    namespace: kube-system
+    server: https://kubernetes.default.svc
+  project: kubeaid
+  sources:
+    - repoURL: {{ .KubeaidFork.URL }}
+      path: argocd-helm-charts/aws-ebs-csi-driver
+      targetRevision: {{ .KubeaidFork.Version }}
+      helm:
+        valueFiles:
+          - $values/k8s/{{ .KubeaidConfigFork.Directory }}/argocd-apps/values-aws-ebs-csi-driver.yaml
+    - repoURL: {{ .KubeaidConfigFork.URL }}
+      targetRevision: HEAD
+      ref: values
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+      - ApplyOutOfSyncOnly=true

--- a/pkg/core/templates/argocd-apps/values-aws-ebs-csi-driver.yaml.tmpl
+++ b/pkg/core/templates/argocd-apps/values-aws-ebs-csi-driver.yaml.tmpl
@@ -1,0 +1,16 @@
+---
+aws-ebs-csi-driver:
+  # EKS installs no storage driver by default — this is the cluster's default
+  # StorageClass. The CSI controller needs EBS permissions (the AWS managed
+  # AmazonEBSCSIDriverPolicy) granted to whatever identity it runs under —
+  # the nodes.cluster-api-provider-aws.sigs.k8s.io instance profile, or IRSA
+  # once wired.
+  storageClasses:
+    - name: gp3
+      annotations:
+        storageclass.kubernetes.io/is-default-class: "true"
+      volumeBindingMode: WaitForFirstConsumer
+      allowVolumeExpansion: true
+      parameters:
+        type: gp3
+        encrypted: "true"

--- a/pkg/core/templates/argocd-apps/values-capi-cluster.yaml.tmpl
+++ b/pkg/core/templates/argocd-apps/values-capi-cluster.yaml.tmpl
@@ -37,6 +37,26 @@ global:
 provider:
   aws: true
 
+{{- if .AWSConfig.EKS }}
+
+aws:
+  # AWS managed (EKS) control plane : the chart renders AWSManagedControlPlane
+  # + AWSManagedCluster instead of AWSCluster + KubeadmControlPlane. Workers
+  # stay self-managed MachineDeployments, bootstrapped via NodeadmConfig on
+  # EKS optimized AL2023 AMIs that CAPA resolves itself — hence no sshKeyName,
+  # no controlPlane block and no per-node-group AMI IDs here.
+  eks: true
+  secretName: cloud-credentials
+  region: {{ .AWSConfig.Region }}
+  bastion:
+    enabled: {{ .AWSConfig.BastionEnabled }}
+  vpc:
+    cidrBlock: 10.14.0.0/22
+  pods:
+    cidrBlock: 10.244.0.0/16
+  nodeGroups: {{- .AWSConfig.NodeGroups | toYaml | nindent 4 }}
+{{- else }}
+
 aws:
   # Currently, hostNetworking must be set to true.
   # Otherwise, during the Kubernetes version upgrade process, when the control-plane nodes get
@@ -69,6 +89,7 @@ aws:
       files: {{- .ClusterConfig.APIServer.Files | toYaml | nindent 8 }}
     {{- end }}
   nodeGroups: {{- .AWSConfig.NodeGroups | toYaml | nindent 4 }}
+{{- end }}
 {{- end }}
 
 {{- if .AzureConfig }}

--- a/pkg/core/templates/argocd-apps/values-cilium.yaml.tmpl
+++ b/pkg/core/templates/argocd-apps/values-cilium.yaml.tmpl
@@ -4,7 +4,7 @@ cilium:
   {{- if .ControlPlaneEndpoint }}
   kubeProxyReplacement: "true"
   k8sServiceHost: {{ .ControlPlaneEndpoint }}
-  k8sServicePort: 6443
+  k8sServicePort: {{ .ControlPlaneEndpointPort }}
   {{- end }}
 
   {{- if .HetznerBareMetalFirewallEnabled }}

--- a/pkg/render/config.go
+++ b/pkg/render/config.go
@@ -119,7 +119,10 @@ type PromptedConfig struct {
 	CloudProvider string
 
 	// AWS.
-	AWSRegion          string
+	AWSRegion string
+	// AWSEKS selects an AWS managed (EKS) control plane instead of the
+	// self-managed kubeadm one. Skips the HA / AMI / SSH-key questions.
+	AWSEKS             bool
 	AWSSSHKeyName      string
 	AWSCPInstanceType  string
 	AWSCPReplicas      string

--- a/pkg/render/templates/general.yaml.tmpl
+++ b/pkg/render/templates/general.yaml.tmpl
@@ -67,6 +67,10 @@ cloud:
 {{- if eq .CloudProvider "aws" }}
   aws:
     region: {{ .AWSRegion }}
+{{- if .AWSEKS }}
+    eks: true
+    bastionEnabled: true
+{{- else }}
     sshKeyName: {{ .AWSSSHKeyName }}
     bastionEnabled: true
     controlPlane:
@@ -75,6 +79,7 @@ cloud:
       instanceType: {{ .AWSCPInstanceType }}
       ami:
         id: {{ .AWSAMIID }}
+{{- end }}
 {{- end }}
 {{- if eq .CloudProvider "azure" }}
   azure:


### PR DESCRIPTION
Add cloud.aws.eks to general.yaml : provisions an AWS managed (EKS) control plane via CAPA's AWSManagedControlPlane, with workers staying self-managed MachineDeployments bootstrapped through NodeadmConfig on EKS optimized AL2023 AMIs (CAPA's stable EKS worker path; requires Kubernetes >= v1.33).

- config: EKS flag + cross-field validation (controlPlane / sshKeyName / node-group AMIs must stay unset; >= 1 node-group; K8s >= v1.33)
- prompt: control-plane flavour asked before credentials; EKS skips the HA, AMI and SSH-key questions
- addons: EKS set drops ccm-aws (EKS runs the cloud controller) and adds aws-ebs-csi-driver (default gp3 StorageClass); Cilium values take the apiserver port from the kubeconfig (EKS listens on 443)
- bootstrap: Cilium is helm-installed into the EKS cluster (no KubeadmControlPlane postKubeadm hook exists there); pre-pivot CAPA credential zeroing is skipped (workers lack the controllers policy)
- upgrade / recover: rejected for EKS with pointers to the GitOps flow (bump global.kubernetes.version in values-capi-cluster.yaml)