### PR TITLE
fix(render): always emit git's privateKeyFilePath without an agent

### DIFF
--- a/pkg/render/render_golden_test.go
+++ b/pkg/render/render_golden_test.go
@@ -319,3 +319,51 @@ func TestRenderNilConfig(t *testing.T) {
 	assert.Nil(t, general)
 	assert.Nil(t, secrets)
 }
+
+// TestRenderAlwaysEmitsGitKeyPathWithoutAgent pins the contract the Obmondo
+// install flow depends on: when the operator is not on an SSH agent, the git
+// block always carries a privateKeyFilePath line, even with no value.
+//
+// The portal ships that value empty on purpose — it cannot know where the key
+// will land, because that depends on --configs-directory — and kubeaid-cli
+// fills it in after writing the key. Omitting the line when the value is empty
+// left nothing to fill, and the operator was asked for a key that had already
+// been delivered.
+//
+// Hetzner's sshKeyPair and both ArgoCD deploy keys already behaved this way;
+// git was the one that did not.
+func TestRenderAlwaysEmitsGitKeyPathWithoutAgent(t *testing.T) {
+	base := goldenCases()[0].cfg
+
+	t.Run("empty path still emits the line", func(t *testing.T) {
+		cfg := *base
+		cfg.UseSSHAgent = false
+		cfg.SSHKeyPath = ""
+
+		general, _, err := Render(&cfg)
+		require.NoError(t, err)
+		assert.Contains(t, string(general), "\n  privateKeyFilePath:",
+			"an empty path must still render the line, or the CLI has nothing to fill")
+	})
+
+	t.Run("a supplied path is rendered unchanged", func(t *testing.T) {
+		cfg := *base
+		cfg.UseSSHAgent = false
+		cfg.SSHKeyPath = "/home/op/.ssh/id_ed25519"
+
+		general, _, err := Render(&cfg)
+		require.NoError(t, err)
+		assert.Contains(t, string(general), "\n  privateKeyFilePath: /home/op/.ssh/id_ed25519")
+	})
+
+	t.Run("the agent path emits no line at all", func(t *testing.T) {
+		cfg := *base
+		cfg.UseSSHAgent = true
+		cfg.SSHKeyPath = ""
+
+		general, _, err := Render(&cfg)
+		require.NoError(t, err)
+		assert.NotContains(t, string(general), "\n  privateKeyFilePath:",
+			"an agent operator has no key file, so the line would be a lie")
+	})
+}

--- a/pkg/render/templates/general.yaml.tmpl
+++ b/pkg/render/templates/general.yaml.tmpl
@@ -1,7 +1,7 @@
 git:
   sshUsername: {{ .SSHUsername }}
   useSSHAgent: {{ .UseSSHAgent }}
-{{- if and (not .UseSSHAgent) .SSHKeyPath }}
+{{- if not .UseSSHAgent }}
   privateKeyFilePath: {{ .SSHKeyPath }}
 {{- end }}
 {{- if .GitKnownHosts }}


### PR DESCRIPTION
The line was rendered only when a path was already known:

  {{- if and (not .UseSSHAgent) .SSHKeyPath }}

The Obmondo portal ships that value empty on purpose. It cannot know where the key will land — that depends on --configs-directory, a local choice — so it leaves the path blank and kubeaid-cli fills it in after writing the key it delivered. With the line omitted there was nothing to fill, so the operator was asked for a key that had already been handed to them.

Hetzner's sshKeyPair and both ArgoCD deploy keys already rendered their line unconditionally. git was the one that did not, which is why three of the four slots worked and this one did not.

No golden fixture changes: all seven use useSSHAgent: true, so the block is skipped in every one. That also means the file-backed path had no golden coverage at all, so the new test covers all three cases — empty path still emits the line, a supplied path is passed through, and an agent operator still gets no line, because for them it would be a lie.