### PR TITLE
feat(azure): add AKS (managed control plane) cluster support

### DIFF
--- a/cmd/kubeaid-core/root/cluster/recover.go
+++ b/cmd/kubeaid-core/root/cluster/recover.go
@@ -18,11 +18,14 @@ var RecoverCmd = &cobra.Command{
 	Short: "Recover a KubeAid managed K8s cluster (from a disaster recovery backup)",
 
 	Run: func(cmd *cobra.Command, args []string) {
-		// EKS recovery isn't wired yet — recover re-runs the bootstrap and the
-		// Velero restore, and neither has been exercised against a managed
-		// control plane. Fail loudly instead of half-recovering.
+		// EKS / AKS recovery isn't wired yet — recover re-runs the bootstrap
+		// and the Velero restore, and neither has been exercised against a
+		// managed control plane. Fail loudly instead of half-recovering.
 		assert.Assert(cmd.Context(), !config.EKSEnabled(),
 			"`cluster recover` doesn't support EKS clusters yet — re-bootstrap and restore from the Velero backup manually",
+		)
+		assert.Assert(cmd.Context(), !config.AKSEnabled(),
+			"`cluster recover` doesn't support AKS clusters yet — re-bootstrap and restore manually",
 		)
 
 		core.RecoverCluster(cmd.Context(),

--- a/cmd/kubeaid-core/root/cluster/upgrade/upgrade.go
+++ b/cmd/kubeaid-core/root/cluster/upgrade/upgrade.go
@@ -62,6 +62,17 @@ var UpgradeCmd = &cobra.Command{
 			})
 
 		case constants.CloudProviderAzure:
+			// AKS clusters are upgraded the GitOps way : Azure owns the
+			// control plane and CAPZ rolls it (plus the agent pools) when the
+			// version in the capi-cluster values changes.
+			if config.AKSEnabled() {
+				assert.Assert(cmd.Context(), false,
+					"`cluster upgrade` doesn't apply to AKS clusters : bump global.kubernetes.version in "+
+						"argocd-apps/values-capi-cluster.yaml in your kubeaid-config repo and let ArgoCD sync — "+
+						"CAPZ then upgrades the AKS control plane and rolls the agent pools",
+				)
+			}
+
 			core.UpgradeCluster(cmd.Context(), core.UpgradeClusterArgs{
 				SkipPRWorkflow: skipPRWorkflow,
 

--- a/docs/superpowers/specs/2026-08-11-aks-support-design.md
+++ b/docs/superpowers/specs/2026-08-11-aks-support-design.md
@@ -1,0 +1,169 @@
+# AKS Support in KubeAid CLI — Design
+
+**Date:** 2026-08-11
+**Status:** Implemented (kubeaid-cli side) — the KubeAid `capi-cluster` chart side is
+follow-up work, see "Chart changes" below
+**Repos affected:** `Obmondo/kubeaid-cli` (this change), `Obmondo/kubeaid` (the
+`capi-cluster` Helm chart — follow-up)
+
+## Goal
+
+Let `kubeaid-cli` provision and manage **Azure AKS** clusters (Azure-managed control
+plane) alongside the existing self-managed CAPZ-based Azure clusters, using the same
+GitOps flow: throwaway K3D management cluster → Cluster API provisions the target →
+`clusterctl move` pivots → ArgoCD reconciles the KubeAid addon stack.
+
+This mirrors the EKS design (`2026-08-09-eks-support-design.md`) wherever the two
+clouds behave the same, and deviates only where AKS forces it to.
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | AKS is a **variant of the existing Azure provider** (`cloud.azure.aks: true`), not a sixth cloud provider | Same reasoning as EKS decision 1: the infrastructure provider stays CAPZ (`azure`); credentials and the provider-name assumptions are shared. |
+| 2 | Workers are **`AzureManagedMachinePool`s** (AKS agent pools), one per node-group; the first node-group renders as the required `System` mode pool, the rest as `User` pools | Unlike CAPA, CAPZ managed clusters support **only** machine pools — MachineDeployments cannot attach to an AKS control plane. `AzureManagedControlPlane` + `AzureManagedCluster` + `AzureManagedMachinePool` is CAPZ's GA managed-cluster path (CAPZ v1.21.1, the version the KubeAid chart pins). The CAPI `MachinePool` feature flag is enabled by default. |
+| 3 | Node autoscaling uses **AKS's built-in cluster autoscaler** (`AzureManagedMachinePool.spec.scaling` from the node-group's minSize/maxSize); the cluster-autoscaler addon is dropped | The CAPI-mode cluster-autoscaler manages MachineDeployments; AKS agent pools are scaled by AKS itself. Managed autoscaler needs no in-cluster pod and no RBAC. |
+| 4 | No machine images and no SSH keys to pick — `sshPublicKey`, `canonicalUbuntuImage`, and `controlPlane.*` must stay **unset** when `aks: true` | AKS owns node images and control-plane sizing. Nodes stay keyless (use `az aks command invoke` / node-shell for debugging), matching the EKS keyless-workers decision. |
+| 5 | **Cilium is the CNI**: the chart sets `AzureManagedControlPlane.spec.networkPlugin: none` (BYO CNI — an allowed enum value in CAPZ v1.21.1), and kubeaid-cli helm-installs the KubeAid cilium chart once the control plane is ready, exactly like the EKS flow. **kube-proxy stays enabled** — unlike EKS there is no supported declarative kube-proxy disable on AKS — so Cilium runs **without** kube-proxy replacement on AKS | Stack uniformity (network policy, Hubble) across KubeAid clusters. BYO-CNI worker nodes stay NotReady until a CNI lands, so the install is a bootstrap step, not an ArgoCD sync; the cilium ArgoCD App adopts the manifests afterwards. |
+| 6 | The prompt asks **self-managed vs AKS before credentials** | Same shape as AWS: credentials are identical either way, but AKS skips the HA question (Azure runs the control plane) and the storage-account derivation (decision 8). |
+| 7 | Lifecycle scope: **bootstrap + delete**. `cluster upgrade` and `cluster recover` are rejected for AKS with pointers to the GitOps flow / roadmap | Same as EKS decision 7: an upgrade is a GitOps edit (bump `global.kubernetes.version` in `values-capi-cluster.yaml`; ArgoCD syncs; CAPZ upgrades the AKS control plane and rolls the agent pools). |
+| 8 | Credentials: AKS uses the **AAD service principal directly**, via an `AzureClusterIdentity` of type `ServicePrincipal` whose client secret is sealed into the existing `capi-cluster/cloud-credentials` Secret. The **entire workload-identity machinery is skipped**: no Crossplane, no storage-account OIDC provider, no UAMIs, no K3D service-account-issuer key mounts, no azure-workload-identity webhook | The self-managed Azure flow needs all of that because CAPZ authenticates via Workload Identity against an operator-hosted OIDC issuer. AKS clusters can lean on AKS's own OIDC issuer (`oidcIssuerProfile.enabled`) for workload IAM later — deferred exactly like IRSA was for EKS. Dropping the machinery removes the `storageAccount`, `workloadIdentity`, and `aadApplication` config requirements for AKS. |
+| 9 | **No storage addons**: AKS ships the Azure Disk / Azure File CSI drivers, their StorageClasses, and the snapshot controller as managed components — `azuredisk-csi-driver`, `external-snapshotter`, and `ccm-azure` are all dropped from the AKS addon set | AKS runs the cloud controller manager and the CSI stack itself. The AKS addon template set is therefore empty beyond the common set (ArgoCD, cert-manager, sealed-secrets, cilium, cluster-api). |
+| 10 | **Disaster recovery is rejected** for AKS in validation (`cloud.disasterRecovery` must be unset) | Azure DR provisioning rides the Crossplane + storage-account + Velero-UAMI machinery that decision 8 removes. DR for AKS needs its own design (likely AKS OIDC + workload identity for Velero); deliberately deferred, not forgotten. |
+
+## Configuration surface
+
+### `general.yaml`
+
+```yaml
+cloud:
+  azure:
+    tenantID: <tenant>
+    subscriptionID: <subscription>
+    location: westeurope
+    aks: true            # NEW — selects the Azure managed (AKS) control plane
+    nodeGroups:          # unchanged shape; becomes AzureManagedMachinePools
+      - name: pool0      # AKS pool names: 1-12 chars, lowercase alphanumeric,
+        vmSize: Standard_D2s_v3   # must start with a letter (validated)
+        diskSizeGB: 128
+        minSize: 3
+        maxSize: 9
+```
+
+Validation when `aks: true`:
+
+- `controlPlane.*`, `sshPublicKey`, `canonicalUbuntuImage`, `storageAccount`,
+  `workloadIdentity`, and `aadApplication` are **rejected** with clear errors —
+  they have no meaning on AKS (decisions 4 and 8).
+- `cloud.disasterRecovery` is rejected (decision 10).
+- At least one node-group is required (an AKS cluster needs a System agent pool
+  and has no control-plane nodes to schedule on), and each node-group name must
+  be a valid AKS agent-pool name (regex `^[a-z][a-z0-9]{0,11}$`).
+
+The previously struct-tag-required fields (`storageAccount`, `sshPublicKey`,
+`canonicalUbuntuImage`, `controlPlane`, `workloadIdentity`, `aadApplication`)
+move to cross-field validation in `validateAzureSelfManagedConfig`, mirroring
+what the EKS change did to `AWSConfig`.
+
+`secrets.yaml` is unchanged: the same `azure.clientID` / `azure.clientSecret`
+service-principal pair. For AKS it is additionally sealed into the
+`capi-cluster/cloud-credentials` Secret that the chart's ServicePrincipal
+`AzureClusterIdentity` references.
+
+### Prompt flow (`pkg/config/prompt/provider_azure.go`)
+
+```
+provider = Azure
+  → NEW select: "Control plane: self-managed (VMs, kubeadm) / AKS (managed by Azure)"
+  → credentials form (tenant / subscription / client ID / client secret)   (unchanged)
+  → [self-managed] HA confirm + storage-account derivation                 (unchanged)
+  → [AKS]          nothing — straight on
+```
+
+The select writes `PromptedConfig.AzureAKS`, consumed by
+`pkg/render/templates/general.yaml.tmpl`, which gains an AKS branch (no
+`storageAccount`, no `controlPlane` block).
+
+## Provisioning flow changes (kubeaid-cli)
+
+1. **Management cluster (K3D)** — the service-account-issuer key mounts and
+   issuer URL are skipped for AKS (`k3d.go` gates on `!config.AKSEnabled()`).
+2. **Cluster-api-operator values** — unchanged: the kubeadm providers stay (the
+   delete path needs them in the management cluster), CAPZ ships the managed
+   control-plane support in the main provider. The `configSecret` block stays
+   azure-suppressed; CAPZ credentials flow through `AzureClusterIdentity`.
+3. **Setup cluster** — the whole Crossplane block (install, provider setup,
+   `ProvisionInfrastructure`, `CreateOIDCProvider`, `GetInfrastructureDetails`,
+   config re-render) is skipped for AKS.
+4. **Addon set** — AKS renders no azure-specific addon templates (decision 9);
+   secret templates swap the crossplane credentials + service-account-issuer
+   keys for the `capi-cluster/cloud-credentials` Secret (client secret).
+5. **Provisioned wait** — `WaitForMainClusterToBeProvisioned`'s predicate
+   becomes managed-control-plane aware: managed clusters have **no
+   control-plane Machines** (so the `cpRunning > 0` gate can never fire), and
+   BYO-CNI worker nodes can't reach the v1beta2 `Ready` aggregate before the
+   CNI is installed — which only happens *after* this wait. For managed CPs the
+   predicate is now: Cluster `Provisioned`+`Ready`, plus (when worker Machines
+   exist — EKS) at least one worker Machine `Running` with a Node ref. AKS
+   agent pools produce no Machine objects at all, so the Cluster conditions
+   carry the gate alone. *This also fixes a latent EKS deadlock — the EKS path
+   had not yet been exercised against real AWS.*
+6. **CNI install** — `installCiliumOnManagedCluster` (generalised from
+   `installCiliumOnEKSCluster`): on EKS it keeps kube-proxy replacement on
+   (kube-proxy is disabled declaratively there); on AKS it installs Cilium
+   without kube-proxy replacement (kube-proxy runs).
+7. **Post-pivot syncs** — the cluster-autoscaler and external-snapshotter
+   ArgoCD app syncs are skipped for AKS (the apps aren't rendered; decision 3
+   and 9). The EKS credential-zeroing skip is AWS-only and doesn't apply.
+8. **Guards** — `cluster upgrade` and `cluster recover` error out for AKS with
+   the GitOps-flow / roadmap pointers, mirroring EKS.
+
+## Chart changes (KubeAid repo, `argocd-helm-charts/capi-cluster`) — FOLLOW-UP
+
+Behind a new `azure.aks` values flag in `charts/azure/`:
+
+- **`AzureManagedControlPlane`** (version, location, resourceGroup,
+  `networkPlugin: none`, `oidcIssuerProfile.enabled: true`, `identityRef`) +
+  **`AzureManagedCluster`**; the `Cluster` template's `controlPlaneRef` /
+  `infrastructureRef` switch to them when `aks` is set; `AzureCluster` +
+  `KubeadmControlPlane` + `KubeadmConfigTemplate` + `AzureMachineTemplate` +
+  `MachineDeployment` render only when it is not.
+- **`AzureClusterIdentity`** gains a ServicePrincipal branch:
+  `type: ServicePrincipal`, `clientID: {{ .Values.azure.clientID }}`,
+  `clientSecret: {name: cloud-credentials, namespace: <ns>}` (key
+  `clientSecret`) — instead of the WorkloadIdentity/UAMI shape.
+- **`MachinePool` + `AzureManagedMachinePool`** per node-group: `mode: System`
+  for the first, `User` for the rest; `sku`, `osDiskSizeGB`,
+  `scaling: {minSize, maxSize}`, taints/labels passthrough.
+- `values.example.aks.yaml` and a helm-unittest suite mirroring
+  `charts/aws/tests/eks_test.yaml`.
+
+Until the chart PR lands, `cluster bootstrap` with `aks: true` renders values
+the chart ignores — pin the kubeaid fork version to a release that contains the
+AKS chart support before using this end-to-end.
+
+## Error handling
+
+- Config validation failures (self-managed-only fields with `aks: true`, DR
+  block, bad pool names, zero node-groups) fail `config generate` /
+  `cluster bootstrap` fast, before any Azure call.
+- `cluster upgrade` / `cluster recover` on an AKS cluster: clear, actionable
+  error — never a silent no-op.
+
+## Testing
+
+- Unit tests for the new validation rules (`pkg/config/parser/validate_test.go`)
+  and addon-set selection.
+- Golden/e2e tests for the new prompt branch and `general.yaml` rendering
+  (`e2e/prompt/prompt_test.go`).
+- **End-to-end against a real Azure subscription is an open item**, same as the
+  real-AWS EKS e2e.
+
+## Out of scope (deliberate)
+
+- Workload identity on AKS (AKS OIDC issuer + azure-workload-identity) — needs
+  its own design; DR on AKS (decision 10) inherits whatever it decides.
+- `cluster upgrade` / `cluster recover` for AKS (decision 7).
+- Azure CNI powered by Cilium (`networkDataplane: cilium`) as an alternative to
+  BYO CNI — revisit if operating our own Cilium on AKS proves painful.
+- Windows agent pools, AKS local accounts hardening, private clusters.

--- a/docs/superpowers/specs/2026-08-11-aks-support-design.md
+++ b/docs/superpowers/specs/2026-08-11-aks-support-design.md
@@ -24,7 +24,7 @@ clouds behave the same, and deviates only where AKS forces it to.
 | 2 | Workers are **`AzureManagedMachinePool`s** (AKS agent pools), one per node-group; the first node-group renders as the required `System` mode pool, the rest as `User` pools | Unlike CAPA, CAPZ managed clusters support **only** machine pools — MachineDeployments cannot attach to an AKS control plane. `AzureManagedControlPlane` + `AzureManagedCluster` + `AzureManagedMachinePool` is CAPZ's GA managed-cluster path (CAPZ v1.21.1, the version the KubeAid chart pins). The CAPI `MachinePool` feature flag is enabled by default. |
 | 3 | Node autoscaling uses **AKS's built-in cluster autoscaler** (`AzureManagedMachinePool.spec.scaling` from the node-group's minSize/maxSize); the cluster-autoscaler addon is dropped | The CAPI-mode cluster-autoscaler manages MachineDeployments; AKS agent pools are scaled by AKS itself. Managed autoscaler needs no in-cluster pod and no RBAC. |
 | 4 | No machine images and no SSH keys to pick — `sshPublicKey`, `canonicalUbuntuImage`, and `controlPlane.*` must stay **unset** when `aks: true` | AKS owns node images and control-plane sizing. Nodes stay keyless (use `az aks command invoke` / node-shell for debugging), matching the EKS keyless-workers decision. |
-| 5 | **Cilium is the CNI**: the chart sets `AzureManagedControlPlane.spec.networkPlugin: none` (BYO CNI — an allowed enum value in CAPZ v1.21.1), and kubeaid-cli helm-installs the KubeAid cilium chart once the control plane is ready, exactly like the EKS flow. **kube-proxy stays enabled** — unlike EKS there is no supported declarative kube-proxy disable on AKS — so Cilium runs **without** kube-proxy replacement on AKS | Stack uniformity (network policy, Hubble) across KubeAid clusters. BYO-CNI worker nodes stay NotReady until a CNI lands, so the install is a bootstrap step, not an ArgoCD sync; the cilium ArgoCD App adopts the manifests afterwards. |
+| 5 | **Cilium is the CNI, kube-proxy-free**: the chart sets `AzureManagedControlPlane.spec.networkPlugin: none` (BYO CNI — an allowed enum value in CAPZ) **and disables kube-proxy** via `ASOManagedClusterPatches` (`networkProfile.kubeProxyConfig.enabled: false` on the underlying ASO ManagedCluster — the classic CAPZ API has no first-class field for it, up to and including v1.26.0). kubeaid-cli then helm-installs the KubeAid cilium chart with `kubeProxyReplacement=true` once the control plane is ready — identical to the EKS flow | Stack uniformity (network policy, Hubble, kube-proxy replacement) across KubeAid clusters. Setting `kubeProxyReplacement` explicitly also sidesteps Cilium's kube-proxy auto-detection, which AKS's `windows-kube-proxy-initializer` DaemonSet is known to confuse. BYO-CNI worker nodes stay NotReady until the CNI lands, so the install is a bootstrap step, not an ArgoCD sync; the cilium ArgoCD App adopts the manifests afterwards. Caveat: AKS's kube-proxy configuration may still require the `KubeProxyConfigurationPreview` feature registered on the subscription (pair the patch with CAPZ's `EnablePreviewFeatures` if so) — verify during the chart work. |
 | 6 | The prompt asks **self-managed vs AKS before credentials** | Same shape as AWS: credentials are identical either way, but AKS skips the HA question (Azure runs the control plane) and the storage-account derivation (decision 8). |
 | 7 | Lifecycle scope: **bootstrap + delete**. `cluster upgrade` and `cluster recover` are rejected for AKS with pointers to the GitOps flow / roadmap | Same as EKS decision 7: an upgrade is a GitOps edit (bump `global.kubernetes.version` in `values-capi-cluster.yaml`; ArgoCD syncs; CAPZ upgrades the AKS control plane and rolls the agent pools). |
 | 8 | Credentials: AKS uses the **AAD service principal directly**, via an `AzureClusterIdentity` of type `ServicePrincipal` whose client secret is sealed into the existing `capi-cluster/cloud-credentials` Secret. The **entire workload-identity machinery is skipped**: no Crossplane, no storage-account OIDC provider, no UAMIs, no K3D service-account-issuer key mounts, no azure-workload-identity webhook | The self-managed Azure flow needs all of that because CAPZ authenticates via Workload Identity against an operator-hosted OIDC issuer. AKS clusters can lean on AKS's own OIDC issuer (`oidcIssuerProfile.enabled`) for workload IAM later — deferred exactly like IRSA was for EKS. Dropping the machinery removes the `storageAccount`, `workloadIdentity`, and `aadApplication` config requirements for AKS. |
@@ -109,9 +109,9 @@ The select writes `PromptedConfig.AzureAKS`, consumed by
    carry the gate alone. *This also fixes a latent EKS deadlock — the EKS path
    had not yet been exercised against real AWS.*
 6. **CNI install** — `installCiliumOnManagedCluster` (generalised from
-   `installCiliumOnEKSCluster`): on EKS it keeps kube-proxy replacement on
-   (kube-proxy is disabled declaratively there); on AKS it installs Cilium
-   without kube-proxy replacement (kube-proxy runs).
+   `installCiliumOnEKSCluster`): both managed flavours install Cilium with
+   kube-proxy replacement on — kube-proxy is disabled declaratively on both
+   (EKS: `spec.kubeProxy.disable`; AKS: the chart's ASO patch, decision 5).
 7. **Post-pivot syncs** — the cluster-autoscaler and external-snapshotter
    ArgoCD app syncs are skipped for AKS (the apps aren't rendered; decision 3
    and 9). The EKS credential-zeroing skip is AWS-only and doesn't apply.
@@ -122,12 +122,20 @@ The select writes `PromptedConfig.AzureAKS`, consumed by
 
 Behind a new `azure.aks` values flag in `charts/azure/`:
 
+- **Bump `global.capz.version`** from v1.21.1 to **v1.26.0** (latest upstream,
+  June 2026) — same move the EKS work made for CAPA. The classic managed API,
+  `networkPlugin: none`, and `ASOManagedClusterPatches` are all verified
+  present at v1.26.0.
 - **`AzureManagedControlPlane`** (version, location, resourceGroup,
-  `networkPlugin: none`, `oidcIssuerProfile.enabled: true`, `identityRef`) +
-  **`AzureManagedCluster`**; the `Cluster` template's `controlPlaneRef` /
-  `infrastructureRef` switch to them when `aks` is set; `AzureCluster` +
-  `KubeadmControlPlane` + `KubeadmConfigTemplate` + `AzureMachineTemplate` +
-  `MachineDeployment` render only when it is not.
+  `networkPlugin: none`, `oidcIssuerProfile.enabled: true`, `identityRef`,
+  and `asoManagedClusterPatches` disabling kube-proxy —
+  `{"spec": {"networkProfile": {"kubeProxyConfig": {"enabled": false}}}}`,
+  plus `enablePreviewFeatures: true` if `KubeProxyConfigurationPreview` is
+  still subscription-gated) + **`AzureManagedCluster`**; the `Cluster`
+  template's `controlPlaneRef` / `infrastructureRef` switch to them when
+  `aks` is set; `AzureCluster` + `KubeadmControlPlane` +
+  `KubeadmConfigTemplate` + `AzureMachineTemplate` + `MachineDeployment`
+  render only when it is not.
 - **`AzureClusterIdentity`** gains a ServicePrincipal branch:
   `type: ServicePrincipal`, `clientID: {{ .Values.azure.clientID }}`,
   `clientSecret: {name: cloud-credentials, namespace: <ns>}` (key

--- a/e2e/prompt/prompt_test.go
+++ b/e2e/prompt/prompt_test.go
@@ -430,7 +430,12 @@ func TestAzure_PromptFlow(t *testing.T) {
 	c.expectString("service-user token")
 	c.sendLine("nbp_e2etoken")
 
-	// Step 3 — Azure credentials (all in one group + HA confirm).
+	// Step 3 — control-plane flavour select (before credentials). Default is
+	// the first option: self-managed.
+	c.expectString("Control plane:")
+	c.acceptDefault()
+
+	// Azure credentials form (all in one group + HA confirm).
 	c.expectString("Tenant ID:")
 	c.sendLine("tenant-123")
 

--- a/pkg/cloud/azure/create_oidc_provider_test.go
+++ b/pkg/cloud/azure/create_oidc_provider_test.go
@@ -28,7 +28,7 @@ func TestCreateOIDCProvider(t *testing.T) {
 		Cloud: config.CloudConfig{
 			Azure: &config.AzureConfig{
 				StorageAccount: "teststorage",
-				WorkloadIdentity: config.WorkloadIdentity{
+				WorkloadIdentity: &config.WorkloadIdentity{
 					OpenIDProviderSSHKeyPair: config.OpenIDProviderSSHKeyPairConfig{
 						PublicKeyFilePath: "/tmp/fake-key.pub",
 					},

--- a/pkg/config/general.go
+++ b/pkg/config/general.go
@@ -477,20 +477,32 @@ type (
 // Azure specific.
 type (
 	AzureConfig struct {
-		TenantID       string         `yaml:"tenantID"       validate:"notblank"`
-		SubscriptionID string         `yaml:"subscriptionID" validate:"notblank"`
-		AADApplication AADApplication `yaml:"aadApplication" validate:"required"`
-		Location       string         `yaml:"location"       validate:"notblank"`
+		TenantID       string          `yaml:"tenantID"       validate:"notblank"`
+		SubscriptionID string          `yaml:"subscriptionID" validate:"notblank"`
+		AADApplication *AADApplication `yaml:"aadApplication"`
+		Location       string          `yaml:"location"       validate:"notblank"`
 
-		StorageAccount string `yaml:"storageAccount" validate:"notblank"`
+		// AKS flips the cluster to an Azure managed (AKS) control plane,
+		// provisioned via CAPZ's AzureManagedControlPlane. Workers become
+		// AKS agent pools (AzureManagedMachinePool — CAPZ managed clusters
+		// support no other worker shape), scaled by AKS's built-in cluster
+		// autoscaler. The control plane, node images and SSH keys are all
+		// Azure-managed, and CAPZ authenticates with the AAD service
+		// principal directly — so controlPlane, sshPublicKey,
+		// canonicalUbuntuImage, storageAccount, workloadIdentity and
+		// aadApplication must be left unset. Cross-field rules live in
+		// pkg/config/parser/validate.go (validateAzureConfig).
+		AKS bool `yaml:"aks"`
 
-		WorkloadIdentity WorkloadIdentity `yaml:"workloadIdentity" validate:"required"`
+		StorageAccount string `yaml:"storageAccount"`
 
-		SSHPublicKey string `yaml:"sshPublicKey" validate:"notblank"`
+		WorkloadIdentity *WorkloadIdentity `yaml:"workloadIdentity"`
 
-		CanonicalUbuntuImage CanonicalUbuntuImage `yaml:"canonicalUbuntuImage" validate:"required"`
+		SSHPublicKey string `yaml:"sshPublicKey"`
 
-		ControlPlane AzureControlPlane            `yaml:"controlPlane" validate:"required"`
+		CanonicalUbuntuImage *CanonicalUbuntuImage `yaml:"canonicalUbuntuImage"`
+
+		ControlPlane *AzureControlPlane           `yaml:"controlPlane,omitempty"`
 		NodeGroups   []AzureAutoScalableNodeGroup `yaml:"nodeGroups"`
 	}
 

--- a/pkg/config/parser/ssh.go
+++ b/pkg/config/parser/ssh.go
@@ -46,6 +46,12 @@ func hydrateSSHKeyPairConfigs() {
 
 	switch globals.CloudProviderName {
 	case constants.CloudProviderAzure:
+		// AKS clusters carry no workloadIdentity block — CAPZ authenticates
+		// with the AAD service principal directly, so there is no OIDC
+		// provider key pair to hydrate.
+		if generalConfig.Cloud.Azure.WorkloadIdentity == nil {
+			break
+		}
 		openIDProviderSSHKeyPair := generalConfig.Cloud.Azure.WorkloadIdentity.OpenIDProviderSSHKeyPair
 
 		hydrateSSHKeyPairConfig(&openIDProviderSSHKeyPair.SSHKeyPairConfig)

--- a/pkg/config/parser/validate.go
+++ b/pkg/config/parser/validate.go
@@ -402,11 +402,11 @@ func validateAWSConfig() error {
 
 	awsConfig := config.ParsedGeneralConfig.Cloud.AWS
 
+	validateControlPlaneFlavour := validateAWSSelfManagedConfig
 	if awsConfig.EKS {
-		if err := validateAWSEKSConfig(awsConfig); err != nil {
-			return err
-		}
-	} else if err := validateAWSSelfManagedConfig(awsConfig); err != nil {
+		validateControlPlaneFlavour = validateAWSEKSConfig
+	}
+	if err := validateControlPlaneFlavour(awsConfig); err != nil {
 		return err
 	}
 
@@ -502,11 +502,11 @@ func validateAzureConfig() error {
 
 	azureConfig := config.ParsedGeneralConfig.Cloud.Azure
 
+	validateControlPlaneFlavour := validateAzureSelfManagedConfig
 	if azureConfig.AKS {
-		if err := validateAzureAKSConfig(azureConfig); err != nil {
-			return err
-		}
-	} else if err := validateAzureSelfManagedConfig(azureConfig); err != nil {
+		validateControlPlaneFlavour = validateAzureAKSConfig
+	}
+	if err := validateControlPlaneFlavour(azureConfig); err != nil {
 		return err
 	}
 

--- a/pkg/config/parser/validate.go
+++ b/pkg/config/parser/validate.go
@@ -501,12 +501,111 @@ func validateAzureConfig() error {
 	}
 
 	azureConfig := config.ParsedGeneralConfig.Cloud.Azure
+
+	if azureConfig.AKS {
+		if err := validateAzureAKSConfig(azureConfig); err != nil {
+			return err
+		}
+	} else if err := validateAzureSelfManagedConfig(azureConfig); err != nil {
+		return err
+	}
+
 	for _, azureAutoScalableNodeGroup := range azureConfig.NodeGroups {
 		if err := validateAutoScalableNodeGroup(
 			&azureAutoScalableNodeGroup.AutoScalableNodeGroup,
 		); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// aksAgentPoolNamePattern matches a valid AKS (Linux) agent-pool name : 1-12
+// characters, lowercase alphanumeric, starting with a letter. Azure rejects
+// anything else at ManagedCluster creation time — validating here fails the
+// config fast instead of erroring against the Azure API mid-bootstrap.
+var aksAgentPoolNamePattern = regexp.MustCompile(`^[a-z][a-z0-9]{0,11}$`)
+
+// validateAzureAKSConfig enforces the cross-field rules of an AKS cluster :
+// Azure owns the control plane and the node images (no replicas / VM size /
+// image to pick, keyless nodes), and CAPZ authenticates with the AAD service
+// principal directly — so the whole workload-identity machinery (storage
+// account hosting the OIDC provider, UAMIs, issuer key pair) stays unset.
+// Workers are AKS agent pools, whose names Azure constrains.
+func validateAzureAKSConfig(azureConfig *config.AzureConfig) error {
+	if azureConfig.ControlPlane != nil {
+		return errors.New(
+			"cloud.azure.controlPlane must not be set when cloud.azure.aks is true — Azure manages the AKS control plane",
+		)
+	}
+	if azureConfig.SSHPublicKey != "" {
+		return errors.New(
+			"cloud.azure.sshPublicKey must not be set when cloud.azure.aks is true — AKS nodes stay keyless (use `az aks command invoke` for node access)",
+		)
+	}
+	if azureConfig.CanonicalUbuntuImage != nil {
+		return errors.New(
+			"cloud.azure.canonicalUbuntuImage must not be set when cloud.azure.aks is true — AKS manages the node images itself",
+		)
+	}
+	if azureConfig.StorageAccount != "" {
+		return errors.New(
+			"cloud.azure.storageAccount must not be set when cloud.azure.aks is true — it only hosts the self-managed workload-identity OIDC provider",
+		)
+	}
+	if azureConfig.WorkloadIdentity != nil {
+		return errors.New(
+			"cloud.azure.workloadIdentity must not be set when cloud.azure.aks is true — CAPZ authenticates with the AAD service principal directly (AKS's own OIDC issuer will back workload identity later)",
+		)
+	}
+	if azureConfig.AADApplication != nil {
+		return errors.New(
+			"cloud.azure.aadApplication must not be set when cloud.azure.aks is true — it only feeds the self-managed workload-identity role assignments",
+		)
+	}
+	if config.ParsedGeneralConfig.Cloud.DisasterRecovery != nil {
+		return errors.New(
+			"cloud.disasterRecovery isn't supported when cloud.azure.aks is true yet — Azure DR provisioning rides the workload-identity machinery AKS clusters skip",
+		)
+	}
+
+	if len(azureConfig.NodeGroups) == 0 {
+		return errors.New(
+			"at least one node-group is required when cloud.azure.aks is true — an AKS cluster needs a System agent pool and has no control-plane nodes to schedule workloads on",
+		)
+	}
+	for _, nodeGroup := range azureConfig.NodeGroups {
+		if !aksAgentPoolNamePattern.MatchString(nodeGroup.Name) {
+			return fmt.Errorf(
+				"cloud.azure.nodeGroups[%s].name is not a valid AKS agent-pool name — 1-12 lowercase alphanumeric characters, starting with a letter",
+				nodeGroup.Name,
+			)
+		}
+	}
+	return nil
+}
+
+// validateAzureSelfManagedConfig enforces the fields a kubeadm based (self
+// managed control plane) Azure cluster needs — previously struct-tag enforced,
+// moved here because they must stay unset for AKS.
+func validateAzureSelfManagedConfig(azureConfig *config.AzureConfig) error {
+	if azureConfig.ControlPlane == nil {
+		return errors.New("cloud.azure.controlPlane is required (unless cloud.azure.aks is true)")
+	}
+	if azureConfig.SSHPublicKey == "" {
+		return errors.New("cloud.azure.sshPublicKey is required (unless cloud.azure.aks is true)")
+	}
+	if azureConfig.CanonicalUbuntuImage == nil {
+		return errors.New("cloud.azure.canonicalUbuntuImage is required (unless cloud.azure.aks is true)")
+	}
+	if azureConfig.StorageAccount == "" {
+		return errors.New("cloud.azure.storageAccount is required (unless cloud.azure.aks is true)")
+	}
+	if azureConfig.WorkloadIdentity == nil {
+		return errors.New("cloud.azure.workloadIdentity is required (unless cloud.azure.aks is true)")
+	}
+	if azureConfig.AADApplication == nil {
+		return errors.New("cloud.azure.aadApplication is required (unless cloud.azure.aks is true)")
 	}
 	return nil
 }

--- a/pkg/config/parser/validate_test.go
+++ b/pkg/config/parser/validate_test.go
@@ -710,11 +710,145 @@ func TestValidateAzureConfig(t *testing.T) {
 			wantErrSub: "azure credentials not provided",
 		},
 		{
-			name:    "Azure credentials with no node-groups passes",
+			name:    "self-managed with the kubeadm fields passes",
 			secrets: &config.SecretsConfig{Azure: &config.AzureCredentials{}},
-			general: &config.GeneralConfig{Cloud: config.CloudConfig{Azure: &config.AzureConfig{}}},
+			general: &config.GeneralConfig{Cloud: config.CloudConfig{Azure: selfManagedAzureConfig()}},
+		},
+		{
+			name:    "self-managed without controlPlane is rejected",
+			secrets: &config.SecretsConfig{Azure: &config.AzureCredentials{}},
+			general: &config.GeneralConfig{Cloud: config.CloudConfig{Azure: func() *config.AzureConfig {
+				c := selfManagedAzureConfig()
+				c.ControlPlane = nil
+				return c
+			}()}},
+			wantErr:    true,
+			wantErrSub: "cloud.azure.controlPlane is required",
+		},
+		{
+			name:    "self-managed without workloadIdentity is rejected",
+			secrets: &config.SecretsConfig{Azure: &config.AzureCredentials{}},
+			general: &config.GeneralConfig{Cloud: config.CloudConfig{Azure: func() *config.AzureConfig {
+				c := selfManagedAzureConfig()
+				c.WorkloadIdentity = nil
+				return c
+			}()}},
+			wantErr:    true,
+			wantErrSub: "cloud.azure.workloadIdentity is required",
+		},
+		{
+			name:    "AKS with a node-group passes",
+			secrets: &config.SecretsConfig{Azure: &config.AzureCredentials{}},
+			general: &config.GeneralConfig{Cloud: config.CloudConfig{Azure: &config.AzureConfig{
+				AKS: true,
+				NodeGroups: []config.AzureAutoScalableNodeGroup{
+					aksNodeGroup("pool0"),
+				},
+			}}},
+		},
+		{
+			name:    "AKS with controlPlane set is rejected",
+			secrets: &config.SecretsConfig{Azure: &config.AzureCredentials{}},
+			general: &config.GeneralConfig{Cloud: config.CloudConfig{Azure: &config.AzureConfig{
+				AKS:          true,
+				ControlPlane: &config.AzureControlPlane{},
+			}}},
+			wantErr:    true,
+			wantErrSub: "cloud.azure.controlPlane must not be set",
+		},
+		{
+			name:    "AKS with sshPublicKey set is rejected",
+			secrets: &config.SecretsConfig{Azure: &config.AzureCredentials{}},
+			general: &config.GeneralConfig{Cloud: config.CloudConfig{Azure: &config.AzureConfig{
+				AKS:          true,
+				SSHPublicKey: "ssh-ed25519 AAAA",
+			}}},
+			wantErr:    true,
+			wantErrSub: "cloud.azure.sshPublicKey must not be set",
+		},
+		{
+			name:    "AKS with storageAccount set is rejected",
+			secrets: &config.SecretsConfig{Azure: &config.AzureCredentials{}},
+			general: &config.GeneralConfig{Cloud: config.CloudConfig{Azure: &config.AzureConfig{
+				AKS:            true,
+				StorageAccount: "clustersa",
+			}}},
+			wantErr:    true,
+			wantErrSub: "cloud.azure.storageAccount must not be set",
+		},
+		{
+			name:    "AKS with workloadIdentity set is rejected",
+			secrets: &config.SecretsConfig{Azure: &config.AzureCredentials{}},
+			general: &config.GeneralConfig{Cloud: config.CloudConfig{Azure: &config.AzureConfig{
+				AKS:              true,
+				WorkloadIdentity: &config.WorkloadIdentity{},
+			}}},
+			wantErr:    true,
+			wantErrSub: "cloud.azure.workloadIdentity must not be set",
+		},
+		{
+			name:    "AKS with disasterRecovery set is rejected",
+			secrets: &config.SecretsConfig{Azure: &config.AzureCredentials{}},
+			general: &config.GeneralConfig{Cloud: config.CloudConfig{
+				Azure: &config.AzureConfig{
+					AKS: true,
+					NodeGroups: []config.AzureAutoScalableNodeGroup{
+						aksNodeGroup("pool0"),
+					},
+				},
+				DisasterRecovery: &config.DisasterRecoveryConfig{},
+			}},
+			wantErr:    true,
+			wantErrSub: "cloud.disasterRecovery isn't supported",
+		},
+		{
+			name:    "AKS without node-groups is rejected",
+			secrets: &config.SecretsConfig{Azure: &config.AzureCredentials{}},
+			general: &config.GeneralConfig{Cloud: config.CloudConfig{Azure: &config.AzureConfig{
+				AKS: true,
+			}}},
+			wantErr:    true,
+			wantErrSub: "at least one node-group is required",
+		},
+		{
+			name:    "AKS with an invalid agent-pool name is rejected",
+			secrets: &config.SecretsConfig{Azure: &config.AzureCredentials{}},
+			general: &config.GeneralConfig{Cloud: config.CloudConfig{Azure: &config.AzureConfig{
+				AKS: true,
+				NodeGroups: []config.AzureAutoScalableNodeGroup{
+					aksNodeGroup("Primary-Pool"),
+				},
+			}}},
+			wantErr:    true,
+			wantErrSub: "is not a valid AKS agent-pool name",
 		},
 	}, validateAzureConfig)
+}
+
+// selfManagedAzureConfig returns an AzureConfig carrying every field the
+// self-managed (kubeadm) validation path requires.
+func selfManagedAzureConfig() *config.AzureConfig {
+	return &config.AzureConfig{
+		SSHPublicKey:         "ssh-ed25519 AAAA",
+		StorageAccount:       "clustersa",
+		AADApplication:       &config.AADApplication{PrincipalID: "principal"},
+		WorkloadIdentity:     &config.WorkloadIdentity{},
+		CanonicalUbuntuImage: &config.CanonicalUbuntuImage{Offer: "offer", SKU: "sku"},
+		ControlPlane:         &config.AzureControlPlane{},
+	}
+}
+
+// aksNodeGroup returns a minimal AKS node-group with the given agent-pool name.
+func aksNodeGroup(name string) config.AzureAutoScalableNodeGroup {
+	return config.AzureAutoScalableNodeGroup{
+		AutoScalableNodeGroup: config.AutoScalableNodeGroup{
+			NodeGroup: config.NodeGroup{Name: name},
+			MinSize:   1,
+			Maxsize:   3,
+		},
+		VMSize:     "Standard_D2s_v3",
+		DiskSizeGB: 128,
+	}
 }
 
 func TestValidateHetznerConfig(t *testing.T) {

--- a/pkg/config/predicates.go
+++ b/pkg/config/predicates.go
@@ -24,6 +24,21 @@ func EKSEnabled() bool {
 	return ParsedGeneralConfig.Cloud.AWS != nil && ParsedGeneralConfig.Cloud.AWS.EKS
 }
 
+// AKSEnabled reports whether the cluster runs an Azure managed (AKS) control
+// plane — CAPZ AzureManagedControlPlane instead of KubeadmControlPlane, with
+// workers as AKS agent pools (AzureManagedMachinePool).
+func AKSEnabled() bool {
+	return ParsedGeneralConfig.Cloud.Azure != nil && ParsedGeneralConfig.Cloud.Azure.AKS
+}
+
+// ManagedControlPlaneEnabled reports whether the cloud provider owns the
+// control plane (EKS or AKS). Such clusters have no control-plane Machines or
+// Nodes, no KubeadmControlPlane, and get their CNI installed by kubeaid-cli
+// itself instead of a postKubeadm hook.
+func ManagedControlPlaneEnabled() bool {
+	return EKSEnabled() || AKSEnabled()
+}
+
 // Returns whether we're using HCloud.
 func UsingHCloud() bool {
 	if ParsedGeneralConfig.Cloud.Hetzner == nil {

--- a/pkg/config/prompt/provider_aws.go
+++ b/pkg/config/prompt/provider_aws.go
@@ -248,10 +248,9 @@ func (p *awsPrompter) RunCredentialsForm(cfg *PromptedConfig, _ *autoDetectedCon
 		return nil
 	}
 
+	cfg.AWSCPReplicas = "1"
 	if haChoice {
 		cfg.AWSCPReplicas = "3"
-	} else {
-		cfg.AWSCPReplicas = "1"
 	}
 
 	// Attempt to auto-detect AMI from Canonical; fall back to a manual prompt.

--- a/pkg/config/prompt/provider_azure.go
+++ b/pkg/config/prompt/provider_azure.go
@@ -17,6 +17,12 @@ func newAzureProvider() *azurePrompter {
 }
 
 func (p *azurePrompter) SummaryLines(cfg *PromptedConfig) []string {
+	if cfg.AzureAKS {
+		return []string{
+			fmt.Sprintf("  Location:      %s", cfg.AzureLocation),
+			"  Control plane: AKS (managed by Azure)",
+		}
+	}
 	return []string{
 		fmt.Sprintf("  Location:      %s", cfg.AzureLocation),
 		fmt.Sprintf("  VM size:       %s", cfg.AzureCPVMSize),
@@ -37,34 +43,67 @@ func (p *azurePrompter) RunCredentialsForm(cfg *PromptedConfig, _ *autoDetectedC
 		cfg.AzureCPDiskSizeGB = "128"
 	}
 
+	// Control-plane flavour comes BEFORE credentials : the credentials are the
+	// same either way, but every question after them differs — AKS has no HA /
+	// replica choice (Azure runs the control plane) and no storage account
+	// (it only hosts the self-managed workload-identity OIDC provider).
+	if err := huh.NewForm(
+		huh.NewGroup(
+			huh.NewSelect[bool]().
+				Title("Control plane:").
+				Options(
+					huh.NewOption("Self-managed (VMs, kubeadm)", false),
+					huh.NewOption("AKS (managed by Azure)", true),
+				).
+				Value(&cfg.AzureAKS),
+		).Title("Azure control plane").Description("Step 3/4"),
+	).Run(); err != nil {
+		return err
+	}
+
 	haChoice := cfg.AzureCPReplicas != "1"
 
+	credGroup := huh.NewGroup(
+		huh.NewInput().
+			Title("Tenant ID:").
+			Value(&cfg.AzureTenantID).
+			Validate(nonEmpty),
+		huh.NewInput().
+			Title("Subscription ID:").
+			Value(&cfg.AzureSubscriptionID).
+			Validate(nonEmpty),
+		huh.NewInput().
+			Title("Client ID:").
+			Value(&cfg.AzureClientID).
+			Validate(nonEmpty),
+		huh.NewInput().
+			Title("Client Secret:").
+			EchoMode(huh.EchoModePassword).
+			Value(&cfg.AzureClientSecret).
+			Validate(nonEmpty),
+	)
+
+	haGroup := huh.NewGroup(
+		huh.NewConfirm().
+			Title("Enable high availability for the control plane?").
+			Value(&haChoice),
+	).WithHideFunc(func() bool {
+		// AKS control planes are Azure-managed — nothing to ask.
+		return cfg.AzureAKS
+	})
+
 	err := huh.NewForm(
-		huh.NewGroup(
-			huh.NewInput().
-				Title("Tenant ID:").
-				Value(&cfg.AzureTenantID).
-				Validate(nonEmpty),
-			huh.NewInput().
-				Title("Subscription ID:").
-				Value(&cfg.AzureSubscriptionID).
-				Validate(nonEmpty),
-			huh.NewInput().
-				Title("Client ID:").
-				Value(&cfg.AzureClientID).
-				Validate(nonEmpty),
-			huh.NewInput().
-				Title("Client Secret:").
-				EchoMode(huh.EchoModePassword).
-				Value(&cfg.AzureClientSecret).
-				Validate(nonEmpty),
-			huh.NewConfirm().
-				Title("Enable high availability for the control plane?").
-				Value(&haChoice),
-		).Title("Azure credentials").Description("Step 3/4"),
+		credGroup.Title("Azure credentials").Description("Step 3/4 (cont.)"),
+		haGroup,
 	).Run()
 	if err != nil {
 		return err
+	}
+
+	if cfg.AzureAKS {
+		// Azure owns the control plane, and there is no storage account to
+		// derive — nothing more to collect.
+		return nil
 	}
 
 	if haChoice {

--- a/pkg/config/prompt/provider_azure.go
+++ b/pkg/config/prompt/provider_azure.go
@@ -106,10 +106,9 @@ func (p *azurePrompter) RunCredentialsForm(cfg *PromptedConfig, _ *autoDetectedC
 		return nil
 	}
 
+	cfg.AzureCPReplicas = "1"
 	if haChoice {
 		cfg.AzureCPReplicas = "3"
-	} else {
-		cfg.AzureCPReplicas = "1"
 	}
 
 	// Auto-generate storage account name from cluster name.

--- a/pkg/config/prompt/provider_azure.go
+++ b/pkg/config/prompt/provider_azure.go
@@ -52,7 +52,7 @@ func (p *azurePrompter) RunCredentialsForm(cfg *PromptedConfig, _ *autoDetectedC
 			huh.NewSelect[bool]().
 				Title("Control plane:").
 				Options(
-					huh.NewOption("Self-managed (VMs, kubeadm)", false),
+					huh.NewOption("Self-managed (Azure VMs, kubeadm)", false),
 					huh.NewOption("AKS (managed by Azure)", true),
 				).
 				Value(&cfg.AzureAKS),

--- a/pkg/config/prompt/resume.go
+++ b/pkg/config/prompt/resume.go
@@ -226,13 +226,16 @@ func applyCloudConfigToPromptedConfig(cloud *config.CloudConfig, cfg *PromptedCo
 		}
 	case cloud.Azure != nil:
 		cfg.CloudProvider = constants.CloudProviderAzure
+		cfg.AzureAKS = cfg.AzureAKS || cloud.Azure.AKS
 		cfg.AzureTenantID = firstNonEmpty(cloud.Azure.TenantID, cfg.AzureTenantID)
 		cfg.AzureSubscriptionID = firstNonEmpty(cloud.Azure.SubscriptionID, cfg.AzureSubscriptionID)
 		cfg.AzureLocation = firstNonEmpty(cloud.Azure.Location, cfg.AzureLocation)
 		cfg.AzureStorageAccount = firstNonEmpty(cloud.Azure.StorageAccount, cfg.AzureStorageAccount)
-		cfg.AzureCPVMSize = firstNonEmpty(cloud.Azure.ControlPlane.VMSize, cfg.AzureCPVMSize)
-		cfg.AzureCPReplicas = firstNonEmpty(uint32String(cloud.Azure.ControlPlane.Replicas), cfg.AzureCPReplicas)
-		cfg.AzureCPDiskSizeGB = firstNonEmpty(uint32String(cloud.Azure.ControlPlane.DiskSizeGB), cfg.AzureCPDiskSizeGB)
+		if cloud.Azure.ControlPlane != nil {
+			cfg.AzureCPVMSize = firstNonEmpty(cloud.Azure.ControlPlane.VMSize, cfg.AzureCPVMSize)
+			cfg.AzureCPReplicas = firstNonEmpty(uint32String(cloud.Azure.ControlPlane.Replicas), cfg.AzureCPReplicas)
+			cfg.AzureCPDiskSizeGB = firstNonEmpty(uint32String(cloud.Azure.ControlPlane.DiskSizeGB), cfg.AzureCPDiskSizeGB)
+		}
 	case cloud.Hetzner != nil:
 		applyHetznerConfigToPromptedConfig(cloud.Hetzner, cfg)
 	case cloud.BareMetal != nil:

--- a/pkg/constants/templates.go
+++ b/pkg/constants/templates.go
@@ -144,12 +144,29 @@ var (
 		"argocd-apps/templates/external-snapshotter.yaml.tmpl",
 	}
 
+	// AKS clusters : Azure runs the cloud controller, the CSI drivers (with
+	// their StorageClasses and the snapshot controller) and the agent-pool
+	// autoscaler itself, and the whole self-managed workload-identity
+	// machinery (Crossplane, storage-account OIDC provider, UAMIs, the
+	// azure-workload-identity webhook) is skipped — so no azure-specific
+	// addon templates are rendered at all beyond the common set.
+	AzureAKSSpecificNonSecretTemplateNames = []string{}
+
 	AzureSpecificSecretTemplateNames = []string{
 		// For CrossPlane.
 		"sealed-secrets/crossplane/azure-credentials.yaml.tmpl",
 
 		// For ClusterAPI.
 		"sealed-secrets/capi-cluster/service-account-issuer-keys.yaml.tmpl",
+	}
+
+	// AKS clusters : CAPZ authenticates with the AAD service principal via an
+	// AzureClusterIdentity of type ServicePrincipal, whose client secret the
+	// chart reads from the cloud-credentials Secret — the same Secret name the
+	// AWS and Hetzner providers seal their credentials into.
+	AzureAKSSpecificSecretTemplateNames = []string{
+		// For Cluster API.
+		"sealed-secrets/capi-cluster/cloud-credentials.yaml.tmpl",
 	}
 
 	AzureDisasterRecoverySpecificNonSecretTemplateNames = []string{

--- a/pkg/core/bootstrap_cluster.go
+++ b/pkg/core/bootstrap_cluster.go
@@ -375,17 +375,18 @@ func provisionAndSetupMainCluster(ctx context.Context, args ProvisionAndSetupMai
 	// actual problem (CNI not Ready on the CP Node).
 	bar := progress.FromCtx(ctx)
 	switch {
-	// EKS clusters have no control-plane Nodes to check, and no
-	// KubeadmControlPlane postKubeadm hook to install the CNI : AWS's default
-	// VPC CNI and kube-proxy are disabled declaratively (AWSManagedControlPlane
-	// spec), so kubeaid-cli installs Cilium itself — the worker Nodes stay
-	// NotReady until it lands. The cilium ArgoCD App adopts these manifests
-	// once the main cluster's ArgoCD is up.
-	case config.EKSEnabled():
-		releaseCNI := bar.InProgress("Installing Cilium on the EKS cluster")
-		installCiliumOnEKSCluster(ctx)
+	// Managed control-plane (EKS / AKS) clusters have no control-plane Nodes
+	// to check, and no KubeadmControlPlane postKubeadm hook to install the
+	// CNI : the cloud's default CNI is disabled (EKS : vpcCni.disable on the
+	// AWSManagedControlPlane; AKS : networkPlugin "none" — BYO CNI), so
+	// kubeaid-cli installs Cilium itself — the worker Nodes stay NotReady
+	// until it lands. The cilium ArgoCD App adopts these manifests once the
+	// main cluster's ArgoCD is up.
+	case config.ManagedControlPlaneEnabled():
+		releaseCNI := bar.InProgress("Installing Cilium on the managed cluster")
+		installCiliumOnManagedCluster(ctx)
 		releaseCNI()
-		bar.Substep("Installed Cilium on the EKS cluster")
+		bar.Substep("Installed Cilium on the managed cluster")
 	default:
 		releaseNet := bar.InProgress("Waiting for control-plane Node networking to be ready")
 		err = kubernetes.WaitForCPNodesNetworkingReady(ctx, provisionedClusterClient)
@@ -464,8 +465,10 @@ func provisionAndSetupMainCluster(ctx context.Context, args ProvisionAndSetupMai
 
 	// Sync cluster-autoscaler on AWS or Azure workload clusters.
 	// Skip Hetzner (chart wiring not in place), bare-metal (no
-	// scaling), Local (k3d), and any VPN cluster (operator-fixed).
-	if !config.VPNClusterEnabled() &&
+	// scaling), Local (k3d), any VPN cluster (operator-fixed), and
+	// AKS (the app isn't rendered — AKS's built-in autoscaler scales
+	// the agent pools).
+	if !config.VPNClusterEnabled() && !config.AKSEnabled() &&
 		(globals.CloudProviderName == constants.CloudProviderAWS ||
 			globals.CloudProviderName == constants.CloudProviderAzure) {
 		releaseAuto := bar.InProgress("Syncing cluster-autoscaler ArgoCD app")
@@ -480,8 +483,9 @@ func provisionAndSetupMainCluster(ctx context.Context, args ProvisionAndSetupMai
 
 	// Sync the external-snapshotter ArgoCD App,
 	// if not using Hetzner (since currently we don't support setting up disaster recovery for
-	// Hetzner 🥴).
-	if globals.CloudProviderName != constants.CloudProviderHetzner {
+	// Hetzner 🥴). AKS skips it too — the app isn't rendered there (AKS ships
+	// the snapshot controller with its managed CSI drivers).
+	if globals.CloudProviderName != constants.CloudProviderHetzner && !config.AKSEnabled() {
 		releaseSnap := bar.InProgress("Syncing external-snapshotter ArgoCD app")
 		err = kubernetes.SyncArgoCDApp(
 			ctx, constants.ArgoCDExternalSnapshotter,
@@ -635,18 +639,28 @@ func pivotCluster(ctx context.Context, mainClusterClient client.Client) {
 	bar.Substep("Pivoted ClusterAPI to main cluster")
 }
 
-// installCiliumOnEKSCluster installs Cilium into the just-provisioned EKS
-// cluster, mirroring what the KubeadmControlPlane postKubeadm hook does on
-// self-managed clusters (helm-render the KubeAid cilium chart with the
-// apiserver endpoint set). EKS has no control-plane nodes to run that hook,
-// and its AWS-default CNI + kube-proxy are disabled via AWSManagedControlPlane
-// (spec.vpcCni.disable / spec.kubeProxy.disable) — so without this install the
-// worker Nodes never turn Ready and nothing else can be scheduled. The cilium
-// ArgoCD App later adopts the same manifests (same chart, same values source).
-func installCiliumOnEKSCluster(ctx context.Context) {
+// installCiliumOnManagedCluster installs Cilium into the just-provisioned
+// managed (EKS / AKS) cluster, mirroring what the KubeadmControlPlane
+// postKubeadm hook does on self-managed clusters (helm-render the KubeAid
+// cilium chart with the apiserver endpoint set). Managed clusters have no
+// control-plane nodes to run that hook, and their cloud-default CNI is
+// disabled (EKS : AWSManagedControlPlane's vpcCni.disable; AKS :
+// networkPlugin "none") — so without this install the worker Nodes never turn
+// Ready and nothing else can be scheduled. The cilium ArgoCD App later adopts
+// the same manifests (same chart, same values source).
+//
+// kube-proxy replacement is enabled only on EKS, where kube-proxy is disabled
+// declaratively (spec.kubeProxy.disable). AKS always runs kube-proxy, so
+// Cilium runs alongside it there — matching values-cilium.yaml.tmpl.
+func installCiliumOnManagedCluster(ctx context.Context) {
 	endpoint, err := kubernetes.GetMainClusterEndpoint(ctx)
 	assert.AssertErrNil(ctx, err, "Failed getting main cluster endpoint")
 	assert.AssertNotNil(ctx, endpoint, "Main cluster kubeconfig has no endpoint — cannot install Cilium")
+
+	kubeProxyReplacement := "true"
+	if config.AKSEnabled() {
+		kubeProxyReplacement = "false"
+	}
 
 	// KUBECONFIG already points at the main cluster's kubeconfig here — the
 	// Helm SDK picks it up from the environment.
@@ -657,13 +671,13 @@ func installCiliumOnEKSCluster(ctx context.Context) {
 		ReleaseName: "cilium",
 		Values: &helmValues.Options{
 			Values: []string{
-				"cilium.kubeProxyReplacement=true",
+				fmt.Sprintf("cilium.kubeProxyReplacement=%s", kubeProxyReplacement),
 				fmt.Sprintf("cilium.k8sServiceHost=%s", endpoint.Hostname()),
 				fmt.Sprintf("cilium.k8sServicePort=%s", endpoint.Port()),
 			},
 		},
 	})
-	assert.AssertErrNil(ctx, err, "Failed installing Cilium on the EKS cluster")
+	assert.AssertErrNil(ctx, err, "Failed installing Cilium on the managed cluster")
 }
 
 func provisionMainClusterUsingKubeOne(ctx context.Context) {

--- a/pkg/core/bootstrap_cluster.go
+++ b/pkg/core/bootstrap_cluster.go
@@ -649,18 +649,17 @@ func pivotCluster(ctx context.Context, mainClusterClient client.Client) {
 // Ready and nothing else can be scheduled. The cilium ArgoCD App later adopts
 // the same manifests (same chart, same values source).
 //
-// kube-proxy replacement is enabled only on EKS, where kube-proxy is disabled
-// declaratively (spec.kubeProxy.disable). AKS always runs kube-proxy, so
-// Cilium runs alongside it there — matching values-cilium.yaml.tmpl.
+// Both managed flavours run kube-proxy-free with Cilium's replacement : EKS
+// disables kube-proxy via AWSManagedControlPlane.spec.kubeProxy.disable, AKS
+// via the chart's ASOManagedClusterPatches (networkProfile.kubeProxyConfig.
+// enabled=false — the classic CAPZ API has no first-class field for it).
+// Setting kubeProxyReplacement explicitly also sidesteps Cilium's kube-proxy
+// auto-detection, which AKS's windows-kube-proxy-initializer DaemonSet
+// confuses.
 func installCiliumOnManagedCluster(ctx context.Context) {
 	endpoint, err := kubernetes.GetMainClusterEndpoint(ctx)
 	assert.AssertErrNil(ctx, err, "Failed getting main cluster endpoint")
 	assert.AssertNotNil(ctx, endpoint, "Main cluster kubeconfig has no endpoint — cannot install Cilium")
-
-	kubeProxyReplacement := "true"
-	if config.AKSEnabled() {
-		kubeProxyReplacement = "false"
-	}
 
 	// KUBECONFIG already points at the main cluster's kubeconfig here — the
 	// Helm SDK picks it up from the environment.
@@ -671,7 +670,7 @@ func installCiliumOnManagedCluster(ctx context.Context) {
 		ReleaseName: "cilium",
 		Values: &helmValues.Options{
 			Values: []string{
-				fmt.Sprintf("cilium.kubeProxyReplacement=%s", kubeProxyReplacement),
+				"cilium.kubeProxyReplacement=true",
 				fmt.Sprintf("cilium.k8sServiceHost=%s", endpoint.Hostname()),
 				fmt.Sprintf("cilium.k8sServicePort=%s", endpoint.Port()),
 			},

--- a/pkg/core/setup_cluster.go
+++ b/pkg/core/setup_cluster.go
@@ -315,6 +315,14 @@ func SetupCluster(ctx context.Context, args SetupClusterArgs) {
 	// Any cloud provider specific tasks.
 	switch globals.CloudProviderName {
 	case constants.CloudProviderAzure:
+		// AKS clusters skip the whole workload-identity machinery : CAPZ
+		// authenticates with the AAD service principal directly, so there is
+		// no Crossplane-provisioned infrastructure (storage account, UAMIs)
+		// and no OIDC provider to create.
+		if config.AKSEnabled() {
+			break
+		}
+
 		// Install CrossPlane.
 		// Then set it up, by installing required Providers, Functions, Compositions and
 		// Composite Resource Definitions (XRDs).

--- a/pkg/core/templates.go
+++ b/pkg/core/templates.go
@@ -428,9 +428,13 @@ func getTemplateValues(ctx context.Context) *TemplateValues {
 		)
 
 	case constants.CloudProviderAzure:
-		saIssuerURL, saErr := azure.GetServiceAccountIssuerURL()
-		assert.AssertErrNil(ctx, saErr, "Failed getting Azure ServiceAccount issuer URL")
-		templateValues.ServiceAccountIssuerURL = saIssuerURL
+		// AKS clusters have no operator-hosted OIDC provider — the issuer URL
+		// derives from the storage account, which AKS configs don't carry.
+		if !config.AKSEnabled() {
+			saIssuerURL, saErr := azure.GetServiceAccountIssuerURL()
+			assert.AssertErrNil(ctx, saErr, "Failed getting Azure ServiceAccount issuer URL")
+			templateValues.ServiceAccountIssuerURL = saIssuerURL
+		}
 	}
 
 	hetznerConfig := templateValues.HetznerConfig
@@ -569,11 +573,14 @@ func getEmbeddedNonSecretTemplateNames() []string {
 		}
 
 	case constants.CloudProviderAzure:
-		embeddedTemplateNames = append(embeddedTemplateNames,
-			constants.AzureSpecificNonSecretTemplateNames...,
-		)
+		azureTemplateNames := constants.AzureSpecificNonSecretTemplateNames
+		if config.AKSEnabled() {
+			azureTemplateNames = constants.AzureAKSSpecificNonSecretTemplateNames
+		}
+		embeddedTemplateNames = append(embeddedTemplateNames, azureTemplateNames...)
 
-		// Add Disaster Recovery related templates, if the user wants disaster recovery.
+		// Add Disaster Recovery related templates, if the user wants disaster
+		// recovery. Validation rejects the DR block for AKS clusters.
 		if config.ParsedGeneralConfig.Cloud.DisasterRecovery != nil {
 			embeddedTemplateNames = append(embeddedTemplateNames,
 				constants.AzureDisasterRecoverySpecificNonSecretTemplateNames...,
@@ -802,11 +809,14 @@ func getEmbeddedSecretTemplateNames() []string {
 		)
 
 	case constants.CloudProviderAzure:
-		embeddedTemplateNames = append(embeddedTemplateNames,
-			constants.AzureSpecificSecretTemplateNames...,
-		)
+		azureSecretTemplateNames := constants.AzureSpecificSecretTemplateNames
+		if config.AKSEnabled() {
+			azureSecretTemplateNames = constants.AzureAKSSpecificSecretTemplateNames
+		}
+		embeddedTemplateNames = append(embeddedTemplateNames, azureSecretTemplateNames...)
 
-		// Add Disaster Recovery related templates, if the user wants disaster recovery.
+		// Add Disaster Recovery related templates, if the user wants disaster
+		// recovery. Validation rejects the DR block for AKS clusters.
 		if config.ParsedGeneralConfig.Cloud.DisasterRecovery != nil {
 			embeddedTemplateNames = append(embeddedTemplateNames,
 				constants.AzureDisasterRecoverySpecificSecretTemplateNames...,

--- a/pkg/core/templates.go
+++ b/pkg/core/templates.go
@@ -528,6 +528,24 @@ func sanitizedHetznerConfigForChart(hetznerConfig *config.HetznerConfig) *config
 	return &sanitized
 }
 
+// awsNonSecretTemplateNames returns the AWS addon template set — the EKS one
+// when the cluster runs a managed control plane.
+func awsNonSecretTemplateNames() []string {
+	if config.EKSEnabled() {
+		return constants.AWSEKSSpecificNonSecretTemplateNames
+	}
+	return constants.AWSSpecificNonSecretTemplateNames
+}
+
+// azureNonSecretTemplateNames returns the Azure addon template set — the AKS
+// one when the cluster runs a managed control plane.
+func azureNonSecretTemplateNames() []string {
+	if config.AKSEnabled() {
+		return constants.AzureAKSSpecificNonSecretTemplateNames
+	}
+	return constants.AzureSpecificNonSecretTemplateNames
+}
+
 // Returns the list of embedded (non Secret) template names based on the underlying cloud provider.
 func getEmbeddedNonSecretTemplateNames() []string {
 	// Templates common for all cloud providers.
@@ -559,11 +577,7 @@ func getEmbeddedNonSecretTemplateNames() []string {
 	// Add cloud provider specific templates.
 	switch globals.CloudProviderName {
 	case constants.CloudProviderAWS:
-		awsTemplateNames := constants.AWSSpecificNonSecretTemplateNames
-		if config.EKSEnabled() {
-			awsTemplateNames = constants.AWSEKSSpecificNonSecretTemplateNames
-		}
-		embeddedTemplateNames = append(embeddedTemplateNames, awsTemplateNames...)
+		embeddedTemplateNames = append(embeddedTemplateNames, awsNonSecretTemplateNames()...)
 
 		// Add Disaster Recovery related templates, if the user wants disaster recovery.
 		if config.ParsedGeneralConfig.Cloud.DisasterRecovery != nil {
@@ -573,11 +587,7 @@ func getEmbeddedNonSecretTemplateNames() []string {
 		}
 
 	case constants.CloudProviderAzure:
-		azureTemplateNames := constants.AzureSpecificNonSecretTemplateNames
-		if config.AKSEnabled() {
-			azureTemplateNames = constants.AzureAKSSpecificNonSecretTemplateNames
-		}
-		embeddedTemplateNames = append(embeddedTemplateNames, azureTemplateNames...)
+		embeddedTemplateNames = append(embeddedTemplateNames, azureNonSecretTemplateNames()...)
 
 		// Add Disaster Recovery related templates, if the user wants disaster
 		// recovery. Validation rejects the DR block for AKS clusters.

--- a/pkg/core/templates/argocd-apps/values-capi-cluster.yaml.tmpl
+++ b/pkg/core/templates/argocd-apps/values-capi-cluster.yaml.tmpl
@@ -96,6 +96,29 @@ aws:
 provider:
   azure: true
 
+{{- if .AzureConfig.AKS }}
+
+azure:
+  # Azure managed (AKS) control plane : the chart renders AzureManagedControlPlane
+  # + AzureManagedCluster + one AzureManagedMachinePool per node-group instead of
+  # AzureCluster + KubeadmControlPlane + MachineDeployments. Azure owns the
+  # control plane, node images and agent-pool autoscaling — hence no
+  # sshPublicKey, canonicalUbuntuImage or controlPlane block here. CAPZ
+  # authenticates with the AAD service principal : an AzureClusterIdentity of
+  # type ServicePrincipal referencing the clientSecret key of the
+  # cloud-credentials Secret.
+  aks: true
+  tenantID: {{ .AzureConfig.TenantID }}
+  subscriptionID: {{ .AzureConfig.SubscriptionID }}
+  location: {{ .AzureConfig.Location }}
+  resourceGroup: {{ .ClusterConfig.Name }}
+
+  clientID: {{ .AzureCredentials.ClientID }}
+  secretName: cloud-credentials
+
+  nodeGroups: {{- .AzureConfig.NodeGroups | toIndentYAML 2 | nindent 4 }}
+{{- else }}
+
 azure:
   tenantID: {{ .AzureConfig.TenantID }}
   subscriptionID: {{ .AzureConfig.SubscriptionID }}
@@ -116,6 +139,7 @@ azure:
   controlPlane: {{- .AzureConfig.ControlPlane | toIndentYAML 2 | nindent 4 }}
 
   nodeGroups: {{- .AzureConfig.NodeGroups | toIndentYAML 2 | nindent 4 }}
+{{- end }}
 {{- end }}
 
 {{- if .HetznerConfig }}

--- a/pkg/core/templates/argocd-apps/values-cilium.yaml.tmpl
+++ b/pkg/core/templates/argocd-apps/values-cilium.yaml.tmpl
@@ -2,7 +2,17 @@
 {{- if or .ControlPlaneEndpoint .HetznerBareMetalFirewallEnabled }}
 cilium:
   {{- if .ControlPlaneEndpoint }}
+  {{- /* AKS clusters always run kube-proxy (there is no supported declarative
+       disable, unlike EKS's AWSManagedControlPlane.spec.kubeProxy.disable),
+       so Cilium runs alongside it without the replacement. Every other
+       cluster shape with a known endpoint replaces kube-proxy. Matches the
+       values installCiliumOnManagedCluster helm-installs at bootstrap, so the
+       cilium ArgoCD App adopts the release without a config flip. */}}
+  {{- if (and .AzureConfig .AzureConfig.AKS) }}
+  kubeProxyReplacement: "false"
+  {{- else }}
   kubeProxyReplacement: "true"
+  {{- end }}
   k8sServiceHost: {{ .ControlPlaneEndpoint }}
   k8sServicePort: {{ .ControlPlaneEndpointPort }}
   {{- end }}

--- a/pkg/core/templates/argocd-apps/values-cilium.yaml.tmpl
+++ b/pkg/core/templates/argocd-apps/values-cilium.yaml.tmpl
@@ -2,17 +2,7 @@
 {{- if or .ControlPlaneEndpoint .HetznerBareMetalFirewallEnabled }}
 cilium:
   {{- if .ControlPlaneEndpoint }}
-  {{- /* AKS clusters always run kube-proxy (there is no supported declarative
-       disable, unlike EKS's AWSManagedControlPlane.spec.kubeProxy.disable),
-       so Cilium runs alongside it without the replacement. Every other
-       cluster shape with a known endpoint replaces kube-proxy. Matches the
-       values installCiliumOnManagedCluster helm-installs at bootstrap, so the
-       cilium ArgoCD App adopts the release without a config flip. */}}
-  {{- if (and .AzureConfig .AzureConfig.AKS) }}
-  kubeProxyReplacement: "false"
-  {{- else }}
   kubeProxyReplacement: "true"
-  {{- end }}
   k8sServiceHost: {{ .ControlPlaneEndpoint }}
   k8sServicePort: {{ .ControlPlaneEndpointPort }}
   {{- end }}

--- a/pkg/core/templates/sealed-secrets/capi-cluster/cloud-credentials.yaml.tmpl
+++ b/pkg/core/templates/sealed-secrets/capi-cluster/cloud-credentials.yaml.tmpl
@@ -10,6 +10,14 @@ stringData:
   AWS_B64ENCODED_CREDENTIALS: {{ .AWSB64EncodedCredentials }}
 {{- end }}
 
+{{- if .AzureConfig }}
+  {{/* Rendered only for AKS clusters (self-managed Azure authenticates CAPZ
+       via Workload Identity instead — see the template-selection gates in
+       pkg/core/templates.go). The chart's ServicePrincipal
+       AzureClusterIdentity references this Secret's clientSecret key. */}}
+  clientSecret: {{ .AzureCredentials.ClientSecret | quote }}
+{{- end }}
+
 {{- if .HetznerConfig }}
   {{/* hcloud key is required by CAPH for every mode, including pure
        bare-metal: the controller's HCloud client initialises at

--- a/pkg/render/config.go
+++ b/pkg/render/config.go
@@ -132,6 +132,10 @@ type PromptedConfig struct {
 	AWSSessionToken    string
 
 	// Azure.
+	// AzureAKS selects an Azure managed (AKS) control plane instead of the
+	// self-managed kubeadm one. Skips the HA question and the
+	// storage-account derivation.
+	AzureAKS            bool
 	AzureTenantID       string
 	AzureSubscriptionID string
 	AzureLocation       string

--- a/pkg/render/render_golden_test.go
+++ b/pkg/render/render_golden_test.go
@@ -92,6 +92,30 @@ func goldenCases() []goldenCase {
 			},
 		},
 		{
+			name: "azure-aks-workload",
+			cfg: &PromptedConfig{
+				SSHUsername:                "git",
+				UseSSHAgent:                true,
+				KubeaidForkURL:             "https://github.com/Obmondo/kubeaid.git",
+				KubeaidVersion:             "31.0.4",
+				KubeaidConfigForkURL:       "git@github.com:acme/kubeaid-config.git",
+				KubeaidConfigDeployKeyPath: "/tmp/ssh-priv",
+				ClusterName:                "azure-aks-acme",
+				ClusterType:                "workload",
+				K8sVersion:                 "v1.35.6",
+
+				CloudProvider: "azure",
+				// AKS: managed control plane — no storage account, no
+				// controlPlane block in the rendered general.yaml.
+				AzureAKS:            true,
+				AzureTenantID:       "11111111-1111-1111-1111-111111111111",
+				AzureSubscriptionID: "22222222-2222-2222-2222-222222222222",
+				AzureLocation:       "westeurope",
+				AzureClientID:       "33333333-3333-3333-3333-333333333333",
+				AzureClientSecret:   "fake&azure:secret",
+			},
+		},
+		{
 			name: "hetzner-hcloud-workload",
 			cfg: &PromptedConfig{
 				SSHUsername:                "git",

--- a/pkg/render/templates/general.yaml.tmpl
+++ b/pkg/render/templates/general.yaml.tmpl
@@ -86,12 +86,16 @@ cloud:
     tenantID: {{ .AzureTenantID }}
     subscriptionID: {{ .AzureSubscriptionID }}
     location: {{ .AzureLocation }}
+{{- if .AzureAKS }}
+    aks: true
+{{- else }}
     storageAccount: {{ .AzureStorageAccount }}
     controlPlane:
       loadBalancerType: Public
       diskSizeGB: {{ .AzureCPDiskSizeGB }}
       vmSize: {{ .AzureCPVMSize }}
       replicas: {{ .AzureCPReplicas }}
+{{- end }}
 {{- end }}
 {{- if eq .CloudProvider "hetzner" }}
   hetzner:

--- a/pkg/render/testdata/golden/azure-aks-workload.general.yaml
+++ b/pkg/render/testdata/golden/azure-aks-workload.general.yaml
@@ -1,0 +1,33 @@
+git:
+  sshUsername: git
+  useSSHAgent: true
+
+forkURLs:
+  kubeaid:
+    url: https://github.com/Obmondo/kubeaid.git
+    version: 31.0.4
+  kubeaidConfig:
+    url: git@github.com:acme/kubeaid-config.git
+    directory: 
+
+cluster:
+  type: workload
+  name: azure-aks-acme
+  k8sVersion: v1.35.6
+  enableAuditLogging: false
+  apiServer:
+    extraArgs: {}
+    extraVolumes: []
+    files: []
+  argoCD:
+    deployKeys:
+      kubeaidConfig:
+        privateKeyFilePath: /tmp/ssh-priv
+
+cloud:
+  azure:
+    tenantID: 11111111-1111-1111-1111-111111111111
+    subscriptionID: 22222222-2222-2222-2222-222222222222
+    location: westeurope
+    aks: true
+

--- a/pkg/render/testdata/golden/azure-aks-workload.secrets.yaml
+++ b/pkg/render/testdata/golden/azure-aks-workload.secrets.yaml
@@ -1,0 +1,4 @@
+
+azure:
+  clientID: "33333333-3333-3333-3333-333333333333"
+  clientSecret: "fake&azure:secret"

--- a/pkg/utils/kubernetes/clusterapi.go
+++ b/pkg/utils/kubernetes/clusterapi.go
@@ -643,14 +643,16 @@ func summarizeCAPIStatus(ctx context.Context, mgmtClient client.Client) ([]capiS
 
 		// Select the right pair of counters once per Machine. Default
 		// to the worker accumulators; the CP label flips them.
+		isCP := isControlPlaneMachine(&m)
 		total, running := &workerTotal, &workerRunning
-		if isControlPlaneMachine(&m) {
+		if isCP {
 			total, running = &cpTotal, &cpRunning
-		} else if m.Status.Phase == string(clusterAPIV1Beta1.MachinePhaseRunning) &&
+		}
+		// "Joined" = a worker whose node registered with the apiserver,
+		// regardless of the v1beta2 Ready aggregate — the managed-control-
+		// plane predicate below needs this weaker signal (see there).
+		if !isCP && m.Status.Phase == string(clusterAPIV1Beta1.MachinePhaseRunning) &&
 			m.Status.NodeRef != nil {
-			// "Joined" = the node registered with the apiserver, regardless
-			// of the v1beta2 Ready aggregate — the managed-control-plane
-			// predicate below needs this weaker signal (see there).
 			workerJoined++
 		}
 		*total++
@@ -683,14 +685,10 @@ func summarizeCAPIStatus(ctx context.Context, mgmtClient client.Client) ([]capiS
 	// least one worker Machine Running with a registered Node. AKS agent
 	// pools are MachinePools and create no Machine objects, so there the
 	// Cluster conditions carry the gate alone.
-	var ready bool
 	if config.ManagedControlPlaneEnabled() {
-		ready = clusterReady && (workerTotal == 0 || workerJoined > 0)
-	} else {
-		ready = clusterReady && cpRunning > 0 && (workerTotal == 0 || workerRunning > 0)
+		return rows, clusterReady && (workerTotal == 0 || workerJoined > 0), firstErr
 	}
-
-	return rows, ready, firstErr
+	return rows, clusterReady && cpRunning > 0 && (workerTotal == 0 || workerRunning > 0), firstErr
 }
 
 // isControlPlaneMachine reports whether the Machine is a control-plane

--- a/pkg/utils/kubernetes/clusterapi.go
+++ b/pkg/utils/kubernetes/clusterapi.go
@@ -623,7 +623,7 @@ func summarizeCAPIStatus(ctx context.Context, mgmtClient client.Client) ([]capiS
 	// real Machine progress lets kubeaid-cli sit through the long
 	// provisioning window with a single accurate spinner rather than
 	// failing-then-retrying downstream.
-	var cpTotal, cpRunning, workerTotal, workerRunning int
+	var cpTotal, cpRunning, workerTotal, workerRunning, workerJoined int
 
 	for _, m := range machines.Items {
 		detail := machineStatusDetail(&m)
@@ -646,6 +646,12 @@ func summarizeCAPIStatus(ctx context.Context, mgmtClient client.Client) ([]capiS
 		total, running := &workerTotal, &workerRunning
 		if isControlPlaneMachine(&m) {
 			total, running = &cpTotal, &cpRunning
+		} else if m.Status.Phase == string(clusterAPIV1Beta1.MachinePhaseRunning) &&
+			m.Status.NodeRef != nil {
+			// "Joined" = the node registered with the apiserver, regardless
+			// of the v1beta2 Ready aggregate — the managed-control-plane
+			// predicate below needs this weaker signal (see there).
+			workerJoined++
 		}
 		*total++
 
@@ -664,7 +670,25 @@ func summarizeCAPIStatus(ctx context.Context, mgmtClient client.Client) ([]capiS
 	// three conditions. The worker check is skipped when cpTotal>0 and
 	// workerTotal==0 so a single-CP cluster (no worker MachineDeployments
 	// declared) doesn't deadlock here.
-	ready := clusterReady && cpRunning > 0 && (workerTotal == 0 || workerRunning > 0)
+	//
+	// Managed control planes (EKS / AKS) need a different gate: no
+	// control-plane Machines exist at all (the cloud owns the control
+	// plane), so `cpRunning > 0` would deadlock the wait forever. And
+	// worker Nodes cannot pass the v1beta2 NodeHealthy aggregate yet —
+	// their CNI is installed by kubeaid-cli right AFTER this wait
+	// (installCiliumOnManagedCluster), so requiring workerRunning here
+	// would be a chicken-and-egg deadlock too. Instead: the Cluster CR
+	// Provisioned+Ready (which implies the managed control plane is up),
+	// plus — when worker Machines exist (EKS MachineDeployments) — at
+	// least one worker Machine Running with a registered Node. AKS agent
+	// pools are MachinePools and create no Machine objects, so there the
+	// Cluster conditions carry the gate alone.
+	var ready bool
+	if config.ManagedControlPlaneEnabled() {
+		ready = clusterReady && (workerTotal == 0 || workerJoined > 0)
+	} else {
+		ready = clusterReady && cpRunning > 0 && (workerTotal == 0 || workerRunning > 0)
+	}
 
 	return rows, ready, firstErr
 }

--- a/pkg/utils/kubernetes/k3d/k3d.go
+++ b/pkg/utils/kubernetes/k3d/k3d.go
@@ -249,7 +249,10 @@ func generateK3DClusterConfigFile(ctx context.Context, clusterName, configPath s
 		ControlPlaneHostname:            globals.ControlPlaneHostname,
 		ControlPlaneLBBootstrapPublicIP: globals.ControlPlaneLBBootstrapPublicIP,
 	}
-	if globals.CloudProviderName == constants.CloudProviderAzure {
+	// AKS clusters skip the workload-identity mounts : CAPZ authenticates with
+	// the AAD service principal directly, so the management cluster hosts no
+	// service-account issuer.
+	if globals.CloudProviderName == constants.CloudProviderAzure && !config.AKSEnabled() {
 		workloadIdentityConfig := config.ParsedGeneralConfig.Cloud.Azure.WorkloadIdentity
 
 		sshKeys := workloadIdentityConfig.OpenIDProviderSSHKeyPair


### PR DESCRIPTION
Adds `cloud.azure.aks: true` to general.yaml — provisions an Azure managed (AKS) control plane via CAPZ's `AzureManagedControlPlane`, with workers as AKS agent pools (`AzureManagedMachinePool`), scaled by AKS's built-in autoscaler. Mirrors the EKS support (#57) wherever the clouds behave the same.

Design doc: `docs/superpowers/specs/2026-08-11-aks-support-design.md`

## What's in

- **config**: `aks` flag + cross-field validation — `controlPlane` / `sshPublicKey` / `canonicalUbuntuImage` / `storageAccount` / `workloadIdentity` / `aadApplication` and the DR block must stay unset; ≥ 1 node-group; AKS agent-pool name rules. Self-managed requiredness moved from struct tags into `validateAzureSelfManagedConfig` (same shape as the EKS change to `AWSConfig`).
- **prompt**: control-plane flavour (self-managed / AKS) asked before credentials; AKS skips the HA question and storage-account derivation.
- **credentials**: CAPZ authenticates with the AAD service principal via a ServicePrincipal `AzureClusterIdentity` — client secret sealed into `capi-cluster/cloud-credentials`. The whole workload-identity machinery (Crossplane, storage-account OIDC provider, UAMIs, K3D issuer-key mounts) is skipped for AKS.
- **addons**: no azure-specific addon templates on AKS — Azure runs the CCM, CSI drivers (incl. snapshot controller) and the agent-pool autoscaler itself.
- **bootstrap**: Cilium helm-installed into the AKS cluster (BYO CNI, `networkPlugin: none`) with `kubeProxyReplacement=true` — kube-proxy is disabled by the chart via `asoManagedClusterPatches` (`networkProfile.kubeProxyConfig.enabled: false`), matching EKS. The provisioned-wait predicate is now managed-CP aware — managed clusters have no control-plane Machines, AKS pools create no Machine objects at all, and workers can't turn Ready before the CNI lands. **This also fixes a latent EKS bootstrap deadlock** (the old predicate required a Running CP Machine + a v1beta2-Ready worker before the CNI install step could ever run).
- **upgrade / recover**: rejected for AKS with pointers to the GitOps flow.

## Not in this PR (follow-ups)

- **KubeAid `capi-cluster` chart**: `azure.aks` flag, `AzureManagedControlPlane` + `AzureManagedCluster` + `AzureManagedMachinePool` templates, ServicePrincipal identity branch — chart section of the design doc. Until that lands, `aks: true` renders values the chart ignores.
- Real-Azure e2e (same open item as EKS).
- Workload identity on AKS (via AKS's own OIDC issuer) and DR.
- Adopting an existing AKS cluster into KubeAid management.

## Verification

- `go build ./...`, `go vet ./...`, full `go test ./...` green (incl. new validation cases, azure-aks golden fixture, and the AWS/Azure e2e prompt flows).
