### PR TITLE
fix(prompt): lowercase the RSA-key validation error (staticcheck ST1005)

### DIFF
--- a/pkg/config/prompt/provider_azure.go
+++ b/pkg/config/prompt/provider_azure.go
@@ -144,7 +144,7 @@ func validateRSAPublicKeyFile(path string) error {
 		return fmt.Errorf("not an SSH public key: %w", err)
 	}
 	if publicKey.Type() != ssh.KeyAlgoRSA {
-		return fmt.Errorf("Azure VMs only accept RSA keys, got %s", publicKey.Type())
+		return fmt.Errorf("azure VMs only accept RSA keys, got %s", publicKey.Type())
 	}
 	return nil
 }


### PR DESCRIPTION
Trailing fix for #61, which merged before this landed on its branch: golangci-lint (staticcheck ST1005) rejects the capitalized error string in `validateRSAPublicKeyFile`.