### PR TITLE
feat(prompt): show az CLI commands for the Azure credential inputs

### DIFF
--- a/pkg/config/prompt/provider_azure.go
+++ b/pkg/config/prompt/provider_azure.go
@@ -291,18 +291,22 @@ func (p *azurePrompter) RunCredentialsForm(cfg *PromptedConfig, _ *autoDetectedC
 	credGroup := huh.NewGroup(
 		huh.NewInput().
 			Title("Tenant ID:").
+			Description("az account show --query tenantId -o tsv").
 			Value(&cfg.AzureTenantID).
 			Validate(nonEmpty),
 		huh.NewInput().
 			Title("Subscription ID:").
+			Description("az account show --query id -o tsv").
 			Value(&cfg.AzureSubscriptionID).
 			Validate(nonEmpty),
 		huh.NewInput().
 			Title("Client ID:").
+			Description("appId from : az ad sp create-for-rbac --role Contributor \\\n  --scopes /subscriptions/<subscription-id>").
 			Value(&cfg.AzureClientID).
 			Validate(nonEmpty),
 		huh.NewInput().
 			Title("Client Secret:").
+			Description("password from the same az ad sp create-for-rbac output").
 			EchoMode(huh.EchoModePassword).
 			Value(&cfg.AzureClientSecret).
 			Validate(nonEmpty),


### PR DESCRIPTION
Each Azure credential input in the bootstrap prompt now shows the `az` CLI command that produces its value, matching the existing hints on the principal-ID and OIDC-key prompts:

- **Tenant ID** — `az account show --query tenantId -o tsv`
- **Subscription ID** — `az account show --query id -o tsv`
- **Client ID** — appId from `az ad sp create-for-rbac --role Contributor --scopes /subscriptions/<subscription-id>`
- **Client Secret** — password from the same `az ad sp create-for-rbac` output

No behavior change — descriptions only.