### PR TITLE
feat(config): ask whether to deploy the optional security apps

### DIFF
--- a/cmd/kubeaid-core/root/config/templates/general.yaml
+++ b/cmd/kubeaid-core/root/config/templates/general.yaml
@@ -87,6 +87,21 @@ cluster:
   # step. nil = ask interactively (legacy behavior); true = apply
   # without prompting (CI-safe); false = skip the step.
   lockdown:
+  # Security selects the optional security ArgoCD Apps. Omitting the block
+  # leaves every one of them off, so an existing cluster's App set does not
+  # change on upgrade.
+  security:
+    # Deploys trivy-operator together with version-checker. They are one
+    # switch because trivy-operator's ImageOutdatedAndVulnerable alert joins
+    # a metric from each — trivy-operator alone installs an alert that can
+    # never fire. The alert only fires when a running image has fixable
+    # Critical/High CVEs AND a newer tag exists upstream, so every alert
+    # carries an upgrade you can actually apply.
+    vulnerabilityScanning: false
+    # Deploys tetragon: eBPF process, network and file events from every
+    # node. Observability-only until you apply TracingPolicy resources.
+    # Requires a BTF-enabled kernel (>= 5.4) on every node.
+    runtimeDetection: false
   # Keycloak declares the Keycloak instance a VPN cluster hosts as
   # NetBird's SSO IdP. Required on cluster.type=vpn (mode=managed →
   # kubeaid-cli installs it; mode=external → operator runs it

--- a/pkg/config/general.go
+++ b/pkg/config/general.go
@@ -167,6 +167,11 @@ type (
 		// without prompting (CI-safe); false = skip the step.
 		Lockdown *bool `yaml:"lockdown"`
 
+		// Security selects the optional security ArgoCD Apps. Omitting the
+		// block leaves every one of them off, so existing clusters keep
+		// their current app set across an upgrade.
+		Security SecurityConfig `yaml:"security"`
+
 		// Keycloak declares the Keycloak instance a VPN cluster hosts as
 		// NetBird's SSO IdP. Required on cluster.type=vpn (mode=managed →
 		// kubeaid-cli installs it; mode=external → operator runs it
@@ -201,6 +206,22 @@ type (
 		// for (cert-manager's selector.dnsZones). Empty matches every
 		// DNS-01 order — fine when this is the only solver.
 		DNSZones []string `yaml:"dnsZones"`
+	}
+
+	// SecurityConfig selects the optional security ArgoCD Apps. Both
+	// default to false so an existing cluster's app set is unchanged
+	// until its config opts in.
+	SecurityConfig struct {
+		// VulnerabilityScanning deploys trivy-operator together with
+		// version-checker. They are one switch because the chart's
+		// ImageOutdatedAndVulnerable alert joins both metrics —
+		// trivy-operator alone yields an alert that cannot fire.
+		VulnerabilityScanning bool `yaml:"vulnerabilityScanning"`
+
+		// RuntimeDetection deploys tetragon. Observability-only until
+		// TracingPolicy resources are applied. Needs a BTF-enabled
+		// kernel (>= 5.4) on every node.
+		RuntimeDetection bool `yaml:"runtimeDetection"`
 	}
 
 	ArgoCDConfig struct {

--- a/pkg/config/predicates.go
+++ b/pkg/config/predicates.go
@@ -200,3 +200,15 @@ func ObmondoIntegrationEnabled() bool {
 		obmondo.CertPath != "" &&
 		obmondo.KeyPath != ""
 }
+
+// VulnerabilityScanningEnabled reports whether to render the trivy-operator
+// and version-checker Apps. Both or neither: the chart's CVE alert joins a
+// metric from each, so trivy-operator alone yields an alert that cannot fire.
+func VulnerabilityScanningEnabled() bool {
+	return ParsedGeneralConfig.Cluster.Security.VulnerabilityScanning
+}
+
+// RuntimeDetectionEnabled reports whether to render the tetragon App.
+func RuntimeDetectionEnabled() bool {
+	return ParsedGeneralConfig.Cluster.Security.RuntimeDetection
+}

--- a/pkg/config/prompt/prompt.go
+++ b/pkg/config/prompt/prompt.go
@@ -282,6 +282,10 @@ func (s *promptSession) runPromptSteps() error {
 		return err
 	}
 
+	if err := s.collectSecurityIfNeeded(); err != nil {
+		return err
+	}
+
 	if err := s.collectGitSSHIfNeeded(); err != nil {
 		return err
 	}
@@ -465,6 +469,72 @@ func (s *promptSession) collectObmondoSupportIfNeeded() error {
 		return fmt.Errorf("collecting Obmondo support config: %w", err)
 	}
 	s.state.ObmondoSupport = true
+
+	return nil
+}
+
+// collectSecurityIfNeeded asks which optional security Apps to deploy. Applies
+// to every cluster type — CVEs and runtime events are not provider-specific.
+func (s *promptSession) collectSecurityIfNeeded() error {
+	if s.state.Security {
+		return nil
+	}
+
+	if err := runSecurityFormFn(s.cfg); err != nil {
+		return fmt.Errorf("collecting security config: %w", err)
+	}
+	s.state.Security = true
+
+	return nil
+}
+
+// runSecurityFormFn is the test seam for the security form.
+var runSecurityFormFn = runSecurityForm
+
+// runSecurityForm asks which optional security Apps to deploy.
+//
+// Risk-exposure monitoring defaults to yes: it is two lightweight workloads
+// and the alert it enables only fires when a fix is actually available.
+// Runtime detection defaults to no — Tetragon is a per-node DaemonSet and,
+// without TracingPolicy resources, produces an event stream rather than
+// alerts.
+func runSecurityForm(cfg *PromptedConfig) error {
+	vulnerabilityScanning := true
+	runtimeDetection := false
+
+	if err := huh.NewForm(
+		huh.NewGroup(
+			huh.NewNote().
+				Title("Risk exposure monitoring").
+				Description("Deploys trivy-operator and version-checker together.\n"+
+					"Alerts when a running image has fixable Critical/High CVEs\n"+
+					"AND a newer tag exists upstream — so every alert has an\n"+
+					"upgrade you can actually apply."),
+			huh.NewConfirm().
+				Title("Enable risk exposure monitoring?").
+				Affirmative("Yes").
+				Negative("No").
+				Value(&vulnerabilityScanning),
+		),
+		huh.NewGroup(
+			huh.NewNote().
+				Title("Runtime detection (Tetragon)").
+				Description("eBPF process, network and file events from every node,\n"+
+					"exported to your log stack. Observability-only until you\n"+
+					"apply TracingPolicy resources.\n\n"+
+					"Needs a BTF-enabled kernel (>= 5.4) on every node."),
+			huh.NewConfirm().
+				Title("Enable runtime detection?").
+				Affirmative("Yes").
+				Negative("No").
+				Value(&runtimeDetection),
+		),
+	).Run(); err != nil {
+		return err
+	}
+
+	cfg.VulnerabilityScanning = &vulnerabilityScanning
+	cfg.RuntimeDetection = &runtimeDetection
 
 	return nil
 }

--- a/pkg/config/prompt/resume.go
+++ b/pkg/config/prompt/resume.go
@@ -404,6 +404,7 @@ func completedPromptStateFromValues(cfg *PromptedConfig) promptState {
 		VPNKeycloak:         cfg.ClusterType != constants.ClusterTypeVPN || !missingVPNKeycloak(cfg),
 		VPNEndpoints:        cfg.ClusterType != constants.ClusterTypeVPN || !missingVPNEndpoints(cfg),
 		WorkloadLockdown:    cfg.ClusterType == constants.ClusterTypeVPN || cfg.Lockdown != nil,
+		Security:            cfg.VulnerabilityScanning != nil || cfg.RuntimeDetection != nil,
 		ProviderCredentials: !missingProviderPromptConfig(cfg),
 		GitSSH:              !missingGitSSH(cfg),
 		ObmondoSupport:      !missingObmondoSupportConfig(cfg),

--- a/pkg/config/prompt/state_helpers.go
+++ b/pkg/config/prompt/state_helpers.go
@@ -11,7 +11,9 @@ type promptState struct {
 	VPNKeycloak  bool `yaml:"vpnKeycloak"`
 	VPNEndpoints bool `yaml:"vpnEndpoints"`
 	// WorkloadLockdown gates the workload Host Firewall (CCNP) step.
-	WorkloadLockdown    bool `yaml:"workloadLockdown"`
+	WorkloadLockdown bool `yaml:"workloadLockdown"`
+	// Security gates the optional security Apps step.
+	Security            bool `yaml:"security"`
 	ProviderCredentials bool `yaml:"providerCredentials"`
 	GitSSH              bool `yaml:"gitSSH"`
 	ObmondoSupport      bool `yaml:"obmondoSupport"`

--- a/pkg/constants/templates.go
+++ b/pkg/constants/templates.go
@@ -240,6 +240,27 @@ var (
 		"argocd-apps/values-rook-ceph.yaml.tmpl",
 	}
 
+	// VulnerabilityScanningTemplateNames are the risk-exposure App + values
+	// templates, rendered when cluster.security.vulnerabilityScanning is set.
+	//
+	// The two Apps ship as one set on purpose: trivy-operator's
+	// ImageOutdatedAndVulnerable alert joins trivy_vulnerability_id with
+	// version_checker_is_latest_version, so trivy-operator without
+	// version-checker installs an alert that can never fire.
+	VulnerabilityScanningTemplateNames = []string{
+		"argocd-apps/templates/trivy-operator.yaml.tmpl",
+		"argocd-apps/values-trivy-operator.yaml.tmpl",
+		"argocd-apps/templates/version-checker.yaml.tmpl",
+		"argocd-apps/values-version-checker.yaml.tmpl",
+	}
+
+	// RuntimeDetectionTemplateNames are the Tetragon App + values templates,
+	// rendered when cluster.security.runtimeDetection is set.
+	RuntimeDetectionTemplateNames = []string{
+		"argocd-apps/templates/tetragon.yaml.tmpl",
+		"argocd-apps/values-tetragon.yaml.tmpl",
+	}
+
 	HetznerBareMetalSpecificSecretTemplateNames = []string{
 		// For Cluster API.
 		"sealed-secrets/capi-cluster/hetzner-ssh-keypair.yaml.tmpl",

--- a/pkg/core/templates.go
+++ b/pkg/core/templates.go
@@ -553,6 +553,22 @@ func getEmbeddedNonSecretTemplateNames() []string {
 		constants.CommonCloudSpecificNonSecretTemplateNames...,
 	)
 
+	// Optional security Apps, opted into via cluster.security. Off by default
+	// so an existing cluster's App set does not change on upgrade.
+	//
+	// trivy-operator and version-checker render together: the chart's
+	// ImageOutdatedAndVulnerable alert joins a metric from each.
+	if config.VulnerabilityScanningEnabled() {
+		embeddedTemplateNames = append(embeddedTemplateNames,
+			constants.VulnerabilityScanningTemplateNames...,
+		)
+	}
+	if config.RuntimeDetectionEnabled() {
+		embeddedTemplateNames = append(embeddedTemplateNames,
+			constants.RuntimeDetectionTemplateNames...,
+		)
+	}
+
 	// If the user has provided a CA bundle for accessing his / her Git repository,
 	// then we need to provide that CA bundle to ArgoCD via a ConfigMap.
 	if len(config.ParsedGeneralConfig.Git.CABundle) > 0 {

--- a/pkg/core/templates/argocd-apps/templates/tetragon.yaml.tmpl
+++ b/pkg/core/templates/argocd-apps/templates/tetragon.yaml.tmpl
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  labels:
+    kubeaid.io/version: {{ .KubeaidFork.Version }}
+    kubeaid.io/managed-by: kubeaid
+    kubeaid.io/sync-order: "10"
+  name: tetragon
+  namespace: argocd
+  finalizers:
+    - argocd.argoproj.io/resources-finalizer
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: tetragon
+  project: kubeaid
+  sources:
+    - repoURL: {{ .KubeaidFork.URL }}
+      path: argocd-helm-charts/tetragon
+      targetRevision: {{ .KubeaidFork.Version }}
+      helm:
+        valueFiles:
+          - $values/k8s/{{ .KubeaidConfigFork.Directory }}/argocd-apps/values-tetragon.yaml
+    - repoURL: {{ .KubeaidConfigFork.URL }}
+      targetRevision: HEAD
+      ref: values
+  syncPolicy:
+    syncOptions:
+      - ApplyOutOfSyncOnly=true
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/pkg/core/templates/argocd-apps/templates/trivy-operator.yaml.tmpl
+++ b/pkg/core/templates/argocd-apps/templates/trivy-operator.yaml.tmpl
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  labels:
+    kubeaid.io/version: {{ .KubeaidFork.Version }}
+    kubeaid.io/managed-by: kubeaid
+    kubeaid.io/sync-order: "10"
+  name: trivy-operator
+  namespace: argocd
+  finalizers:
+    - argocd.argoproj.io/resources-finalizer
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: trivy-system
+  project: kubeaid
+  sources:
+    - repoURL: {{ .KubeaidFork.URL }}
+      path: argocd-helm-charts/trivy-operator
+      targetRevision: {{ .KubeaidFork.Version }}
+      helm:
+        valueFiles:
+          - $values/k8s/{{ .KubeaidConfigFork.Directory }}/argocd-apps/values-trivy-operator.yaml
+    - repoURL: {{ .KubeaidConfigFork.URL }}
+      targetRevision: HEAD
+      ref: values
+  syncPolicy:
+    syncOptions:
+      - ApplyOutOfSyncOnly=true
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/pkg/core/templates/argocd-apps/templates/version-checker.yaml.tmpl
+++ b/pkg/core/templates/argocd-apps/templates/version-checker.yaml.tmpl
@@ -1,0 +1,30 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  labels:
+    kubeaid.io/version: {{ .KubeaidFork.Version }}
+    kubeaid.io/managed-by: kubeaid
+    kubeaid.io/sync-order: "10"
+  name: version-checker
+  namespace: argocd
+  finalizers:
+    - argocd.argoproj.io/resources-finalizer
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: version-checker
+  project: kubeaid
+  sources:
+    - repoURL: {{ .KubeaidFork.URL }}
+      path: argocd-helm-charts/version-checker
+      targetRevision: {{ .KubeaidFork.Version }}
+      helm:
+        valueFiles:
+          - $values/k8s/{{ .KubeaidConfigFork.Directory }}/argocd-apps/values-version-checker.yaml
+    - repoURL: {{ .KubeaidConfigFork.URL }}
+      targetRevision: HEAD
+      ref: values
+  syncPolicy:
+    syncOptions:
+      - ApplyOutOfSyncOnly=true
+      - CreateNamespace=true

--- a/pkg/core/templates/argocd-apps/values-tetragon.yaml.tmpl
+++ b/pkg/core/templates/argocd-apps/values-tetragon.yaml.tmpl
@@ -1,0 +1,9 @@
+# Per-cluster overrides for the tetragon chart.
+#
+# Tetragon ships no TracingPolicy, so out of the box it is observability-only:
+# process, network and file events exported as JSON to stdout, which the
+# openobserve-collector agent picks up. Enforcement (SIGKILL / Override) is
+# opt-in via your own TracingPolicy resources.
+#
+# Requires a kernel with BTF (>= 5.4, CONFIG_DEBUG_INFO_BTF=y) on every node.
+tetragon: {}

--- a/pkg/core/templates/argocd-apps/values-trivy-operator.yaml.tmpl
+++ b/pkg/core/templates/argocd-apps/values-trivy-operator.yaml.tmpl
@@ -1,0 +1,13 @@
+# Per-cluster overrides for the trivy-operator chart.
+# Chart defaults already filter to CRITICAL/HIGH with ignoreUnfixed and enable
+# the ServiceMonitor; only deviations belong here.
+#
+# The trivy-operator key maps to the wrapped upstream subchart; kubeaid is the
+# KubeAid wrapper's own.
+trivy-operator:
+  # Namespaces to leave unscanned, comma-separated.
+  excludeNamespaces: "kube-system,argocd"
+
+kubeaid:
+  prometheusRule:
+    enabled: true

--- a/pkg/core/templates/argocd-apps/values-version-checker.yaml.tmpl
+++ b/pkg/core/templates/argocd-apps/values-version-checker.yaml.tmpl
@@ -1,0 +1,10 @@
+# Per-cluster overrides for the version-checker chart.
+# Supplies the "is a newer tag available" half of ImageOutdatedAndVulnerable.
+#
+# The version-checker key maps to the wrapped upstream subchart.
+version-checker:
+  # Check every container. Set false and annotate pods with
+  # enable.version-checker.io/<container>=true to opt in selectively.
+  defaultTestAll: true
+  # Raise if registry rate limits become a problem.
+  imageCacheTimeout: 30m

--- a/pkg/core/templates_security_test.go
+++ b/pkg/core/templates_security_test.go
@@ -1,0 +1,162 @@
+// Copyright 2026 Obmondo
+// SPDX-License-Identifier: Apache-2.0
+
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Obmondo/kubeaid-cli/pkg/constants"
+)
+
+// securityApp describes one optional security ArgoCD App: the manifest and
+// values templates, and the chart + namespace the manifest must point at.
+type securityApp struct {
+	name       string
+	appTmpl    string
+	valuesTmpl string
+	chartPath  string
+	namespace  string
+	valuesFile string
+}
+
+var securityApps = []securityApp{
+	{
+		name:       "trivy-operator",
+		appTmpl:    "templates/argocd-apps/templates/trivy-operator.yaml.tmpl",
+		valuesTmpl: "templates/argocd-apps/values-trivy-operator.yaml.tmpl",
+		chartPath:  "argocd-helm-charts/trivy-operator",
+		namespace:  "trivy-system",
+		valuesFile: "values-trivy-operator.yaml",
+	},
+	{
+		name:       "version-checker",
+		appTmpl:    "templates/argocd-apps/templates/version-checker.yaml.tmpl",
+		valuesTmpl: "templates/argocd-apps/values-version-checker.yaml.tmpl",
+		chartPath:  "argocd-helm-charts/version-checker",
+		namespace:  "version-checker",
+		valuesFile: "values-version-checker.yaml",
+	},
+	{
+		name:       "tetragon",
+		appTmpl:    "templates/argocd-apps/templates/tetragon.yaml.tmpl",
+		valuesTmpl: "templates/argocd-apps/values-tetragon.yaml.tmpl",
+		chartPath:  "argocd-helm-charts/tetragon",
+		namespace:  "tetragon",
+		valuesFile: "values-tetragon.yaml",
+	},
+}
+
+// TestSecurityApps covers the ArgoCD Application manifests for the optional
+// security Apps: each must point at its KubeAid chart, land in its own
+// namespace, and read its values file out of the kubeaid-config fork.
+func TestSecurityApps(t *testing.T) {
+	for _, app := range securityApps {
+		t.Run(app.name+" Application manifest", func(t *testing.T) {
+			manifest := renderTemplateToMap(t, app.appTmpl, forkTV(""))
+
+			assert.Equal(t, "argoproj.io/v1alpha1", manifest["apiVersion"])
+			assert.Equal(t, "Application", manifest["kind"])
+
+			metadata := subMap(t, manifest, "metadata")
+			assert.Equal(t, app.name, metadata["name"])
+			assert.Equal(t, "argocd", metadata["namespace"])
+
+			labels := subMap(t, metadata, "labels")
+			assert.Equal(t, "kubeaid", labels["kubeaid.io/managed-by"],
+				"the root App selects on this label")
+			assert.Equal(t, "master", labels["kubeaid.io/version"],
+				"pinned to the KubeAid fork version, not the chart version")
+
+			spec := subMap(t, manifest, "spec")
+			assert.Equal(t, "kubeaid", spec["project"])
+
+			destination := subMap(t, spec, "destination")
+			assert.Equal(t, app.namespace, destination["namespace"])
+
+			sources, ok := spec["sources"].([]any)
+			require.True(t, ok, "spec.sources must be a list")
+			require.Len(t, sources, 2,
+				"one source for the KubeAid chart, one ref for the values repo")
+
+			chartSource, ok := sources[0].(map[string]any)
+			require.True(t, ok)
+			assert.Equal(t, app.chartPath, chartSource["path"])
+			assert.Equal(t, "https://example.test/KubeAid.git", chartSource["repoURL"])
+
+			helm, ok := chartSource["helm"].(map[string]any)
+			require.True(t, ok, "the chart source must carry a helm block")
+			valueFiles, ok := helm["valueFiles"].([]any)
+			require.True(t, ok)
+			require.Len(t, valueFiles, 1)
+			assert.Equal(t,
+				"$values/k8s/demo/argocd-apps/"+app.valuesFile,
+				valueFiles[0],
+				"values must resolve through the $values ref into the config fork")
+
+			valuesSource, ok := sources[1].(map[string]any)
+			require.True(t, ok)
+			assert.Equal(t, "values", valuesSource["ref"])
+			assert.Equal(t, "https://example.test/cfg.git", valuesSource["repoURL"])
+		})
+	}
+}
+
+// TestSecurityAppValuesNesting guards the wrapper-chart nesting. The KubeAid
+// charts wrap an upstream subchart of the same name, so overrides sit one
+// level deep — nesting them twice silently sets values nothing reads.
+func TestSecurityAppValuesNesting(t *testing.T) {
+	t.Run("trivy-operator overrides sit directly under the subchart key", func(t *testing.T) {
+		parsed := renderTemplateToMap(t,
+			"templates/argocd-apps/values-trivy-operator.yaml.tmpl", forkTV(""))
+
+		trivy := subMap(t, parsed, "trivy-operator")
+		assert.NotContains(t, trivy, "trivy-operator",
+			"double nesting would set a value the subchart never reads")
+		assert.Contains(t, trivy, "excludeNamespaces")
+
+		// The wrapper's own values, a sibling of the subchart key.
+		kubeaid := subMap(t, parsed, "kubeaid")
+		prometheusRule := subMap(t, kubeaid, "prometheusRule")
+		assert.Equal(t, true, prometheusRule["enabled"])
+	})
+
+	t.Run("version-checker overrides sit directly under the subchart key", func(t *testing.T) {
+		parsed := renderTemplateToMap(t,
+			"templates/argocd-apps/values-version-checker.yaml.tmpl", forkTV(""))
+
+		versionChecker := subMap(t, parsed, "version-checker")
+		assert.NotContains(t, versionChecker, "version-checker",
+			"double nesting would set a value the subchart never reads")
+		assert.Equal(t, true, versionChecker["defaultTestAll"])
+	})
+
+	t.Run("tetragon takes chart defaults", func(t *testing.T) {
+		parsed := renderTemplateToMap(t,
+			"templates/argocd-apps/values-tetragon.yaml.tmpl", forkTV(""))
+		assert.Contains(t, parsed, "tetragon")
+	})
+}
+
+// TestSecurityTemplateNameSets pins the template sets the render path appends.
+//
+// trivy-operator and version-checker belong to one set deliberately: the
+// ImageOutdatedAndVulnerable alert joins a metric from each, so rendering
+// trivy-operator alone installs an alert that can never fire.
+func TestSecurityTemplateNameSets(t *testing.T) {
+	assert.Equal(t, []string{
+		"argocd-apps/templates/trivy-operator.yaml.tmpl",
+		"argocd-apps/values-trivy-operator.yaml.tmpl",
+		"argocd-apps/templates/version-checker.yaml.tmpl",
+		"argocd-apps/values-version-checker.yaml.tmpl",
+	}, constants.VulnerabilityScanningTemplateNames,
+		"version-checker must ship with trivy-operator, never separately")
+
+	assert.Equal(t, []string{
+		"argocd-apps/templates/tetragon.yaml.tmpl",
+		"argocd-apps/values-tetragon.yaml.tmpl",
+	}, constants.RuntimeDetectionTemplateNames)
+}

--- a/pkg/render/config.go
+++ b/pkg/render/config.go
@@ -87,6 +87,15 @@ type PromptedConfig struct {
 	// asked, else the operator's choice. Rendered to cluster.lockdown.
 	Lockdown *bool
 
+	// VulnerabilityScanning is the risk-exposure monitoring decision
+	// (trivy-operator + version-checker): nil when not asked, else the
+	// operator's choice. Rendered to cluster.security.vulnerabilityScanning.
+	VulnerabilityScanning *bool
+
+	// RuntimeDetection is the Tetragon decision: nil when not asked, else
+	// the operator's choice. Rendered to cluster.security.runtimeDetection.
+	RuntimeDetection *bool
+
 	// HCloud-VPN control-plane endpoint FQDN — required when
 	// running a VPN cluster on Hetzner HCloud. Rendered into
 	// cloud.hetzner.controlPlane.hcloud.loadBalancer.endpoint;
@@ -259,6 +268,23 @@ func (c PromptedConfig) LockdownSet() bool { return c.Lockdown != nil }
 
 // LockdownValue is the value for the rendered cluster.lockdown line.
 func (c PromptedConfig) LockdownValue() bool { return c.Lockdown != nil && *c.Lockdown }
+
+// SecurityBlockEnabled reports whether to render the cluster.security block.
+func (c PromptedConfig) SecurityBlockEnabled() bool {
+	return c.VulnerabilityScanning != nil || c.RuntimeDetection != nil
+}
+
+// VulnerabilityScanningValue is the value for the rendered
+// cluster.security.vulnerabilityScanning line.
+func (c PromptedConfig) VulnerabilityScanningValue() bool {
+	return c.VulnerabilityScanning != nil && *c.VulnerabilityScanning
+}
+
+// RuntimeDetectionValue is the value for the rendered
+// cluster.security.runtimeDetection line.
+func (c PromptedConfig) RuntimeDetectionValue() bool {
+	return c.RuntimeDetection != nil && *c.RuntimeDetection
+}
 
 // NetBirdBlockEnabled reports whether to render the cluster.netbird block.
 // VPN clusters host NetBird by definition; workload clusters render it only

--- a/pkg/render/templates/general.yaml.tmpl
+++ b/pkg/render/templates/general.yaml.tmpl
@@ -49,6 +49,11 @@ cluster:
 {{- if .LockdownSet }}
   lockdown: {{ .LockdownValue }}
 {{- end }}
+{{- if .SecurityBlockEnabled }}
+  security:
+    vulnerabilityScanning: {{ .VulnerabilityScanningValue }}
+    runtimeDetection: {{ .RuntimeDetectionValue }}
+{{- end }}
   argoCD:
     deployKeys:
 {{- if .KubeaidIsSSH }}


### PR DESCRIPTION
Adds cluster.security to general.yaml, prompted during config generate, selecting two optional ArgoCD App sets that KubeAid shipped charts for but kubeaid-cli never rendered - so until now they were only reachable by hand-editing kubeaid-config.

  vulnerabilityScanning -> trivy-operator + version-checker
  runtimeDetection      -> tetragon

The two vulnerability apps are one switch, not two. trivy-operator's ImageOutdatedAndVulnerable alert joins trivy_vulnerability_id with version_checker_is_latest_version, so trivy-operator on its own installs an alert that can never fire. Making them separately selectable would let an operator build exactly that trap.

Both fields default to false and the block is omitted entirely when the prompt was never answered, so an existing cluster's App set does not change when its config is regenerated. The prompt itself defaults risk-exposure monitoring to yes (two light workloads, and the alert only fires when a fix is actually available) and runtime detection to no - tetragon is a per-node DaemonSet that, without TracingPolicy resources, produces an event stream rather than alerts.

Per the GitOps model these are config fields only; no CLI flags duplicate them.

Verified with go build, go vet, and the full ./pkg/... suite, plus a new templates_security_test.go covering the three Application manifests, the wrapper-chart values nesting, and the template-name sets.