### PR TITLE
fix(kubernetes): resolve main cluster endpoint via kubeconfig current-context

### DIFF
--- a/e2e/prompt/prompt_test.go
+++ b/e2e/prompt/prompt_test.go
@@ -69,6 +69,15 @@ func TestBareMetal_PromptFlow(t *testing.T) {
 
 	// Step 4 — Git/SSH form: deploy key + config URL in one group,
 	// then Git SSH key in a second group (no SSH agent).
+	// Security form: applies to every provider, runs right before Git/SSH.
+	// Accept both confirms' defaults (risk exposure monitoring = Yes,
+	// runtime detection = Tetragon = No).
+	c.expectString("Enable risk exposure monitoring?")
+	c.acceptDefault()
+
+	c.expectString("Enable runtime detection?")
+	c.acceptDefault()
+
 	c.expectString("ArgoCD deploy key")
 	c.sendLine(sshKeyPath)
 
@@ -151,6 +160,15 @@ func TestLocal_PromptFlow(t *testing.T) {
 	// Step 3 — Local has no credential form.
 
 	// Step 4 — Git/SSH.
+	// Security form: applies to every provider, runs right before Git/SSH.
+	// Accept both confirms' defaults (risk exposure monitoring = Yes,
+	// runtime detection = Tetragon = No).
+	c.expectString("Enable risk exposure monitoring?")
+	c.acceptDefault()
+
+	c.expectString("Enable runtime detection?")
+	c.acceptDefault()
+
 	c.expectString("ArgoCD deploy key")
 	c.sendLine(sshKeyPath)
 
@@ -232,6 +250,15 @@ func TestLocal_PromptFlow_NetBirdDecline(t *testing.T) {
 	// Step 3 — Local has no credential form.
 
 	// Step 4 — Git/SSH.
+	// Security form: applies to every provider, runs right before Git/SSH.
+	// Accept both confirms' defaults (risk exposure monitoring = Yes,
+	// runtime detection = Tetragon = No).
+	c.expectString("Enable risk exposure monitoring?")
+	c.acceptDefault()
+
+	c.expectString("Enable runtime detection?")
+	c.acceptDefault()
+
 	c.expectString("ArgoCD deploy key")
 	c.sendLine(sshKeyPath)
 
@@ -330,10 +357,12 @@ func TestAWS_PromptFlow(t *testing.T) {
 	c.expectString("Enable high availability")
 	c.acceptDefault()
 
-	// After the credentials form returns, AMI lookup runs. If it fails
-	// (no network in CI), manual AMI inputs are shown — one for the
-	// control plane (arm64) and one for the worker node-group (amd64).
-	nextPrompt := c.expectAnyString("AMI ID for the control plane", "ArgoCD deploy key")
+	// AMI lookup runs inside the credentials form, before it returns. If it
+	// fails (no network in CI), manual AMI inputs are shown — one for the
+	// control plane (arm64) and one for the worker node-group (amd64) —
+	// before the form hands off to the security form below. If it
+	// succeeds, the security form's first prompt appears directly.
+	nextPrompt := c.expectAnyString("AMI ID for the control plane", "Enable risk exposure monitoring?")
 	if nextPrompt == "AMI ID for the control plane" {
 		c.sendLine("ami-0e2etestmanualcp1")
 		c.expectString("AMI ID for the worker node-group")
@@ -341,6 +370,15 @@ func TestAWS_PromptFlow(t *testing.T) {
 	}
 
 	// Step 4 — Git/SSH.
+	// Security form: applies to every provider, runs right before Git/SSH.
+	// Accept both confirms' defaults (risk exposure monitoring = Yes,
+	// runtime detection = Tetragon = No).
+	c.expectString("Enable risk exposure monitoring?")
+	c.acceptDefault()
+
+	c.expectString("Enable runtime detection?")
+	c.acceptDefault()
+
 	c.expectString("ArgoCD deploy key")
 	c.sendLine(sshKeyPath)
 
@@ -466,6 +504,15 @@ func TestAzure_PromptFlow(t *testing.T) {
 	c.sendLine("aad-principal-789")
 
 	// Step 4 — Git/SSH.
+	// Security form: applies to every provider, runs right before Git/SSH.
+	// Accept both confirms' defaults (risk exposure monitoring = Yes,
+	// runtime detection = Tetragon = No).
+	c.expectString("Enable risk exposure monitoring?")
+	c.acceptDefault()
+
+	c.expectString("Enable runtime detection?")
+	c.acceptDefault()
+
 	c.expectString("ArgoCD deploy key")
 	c.sendLine(sshKeyPath)
 
@@ -582,6 +629,15 @@ func TestHetznerHCloud_PromptFlow(t *testing.T) {
 	c.acceptDefault()
 
 	// Step 4 — Git/SSH.
+	// Security form: applies to every provider, runs right before Git/SSH.
+	// Accept both confirms' defaults (risk exposure monitoring = Yes,
+	// runtime detection = Tetragon = No).
+	c.expectString("Enable risk exposure monitoring?")
+	c.acceptDefault()
+
+	c.expectString("Enable runtime detection?")
+	c.acceptDefault()
+
 	c.expectString("ArgoCD deploy key")
 	c.sendLine(sshKeyPath)
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -253,6 +253,19 @@ const (
 	HCloudServersSubnetCIDR  = "10.0.0.0/24"
 	HetznerVSwitchSubnetCIDR = "10.0.1.0/24"
 
+	// DefaultPodCIDR is the cluster pod CIDR the capi-cluster chart's
+	// global.pods.cidrBlock defaults to (see
+	// argocd-helm-charts/capi-cluster/values.yaml in the KubeAid repo) when
+	// a cloud-provider-specific override isn't rendered. Managed clusters
+	// (AKS/EKS) install Cilium with ipam.mode=cluster-pool instead of the
+	// chart's default ipam.mode=kubernetes — see
+	// installCiliumOnManagedCluster — and need this same CIDR handed to
+	// Cilium's operator explicitly, since it can't be read back from
+	// Node.spec.podCIDR (that field never gets populated on those managed
+	// control planes; see the fix commit for the full story). Keep this in
+	// sync with the chart's default if that ever changes.
+	DefaultPodCIDR = "10.244.0.0/16"
+
 	HCloudServerImageUbuntu2604 = "ubuntu-26.04"
 
 	HCloudLocationHel1 = "hel1"

--- a/pkg/core/bootstrap_cluster.go
+++ b/pkg/core/bootstrap_cluster.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"path"
+	"strings"
 	"time"
 
 	argoCDV1Alpha1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
@@ -661,21 +662,73 @@ func installCiliumOnManagedCluster(ctx context.Context) {
 	assert.AssertErrNil(ctx, err, "Failed getting main cluster endpoint")
 	assert.AssertNotNil(ctx, endpoint, "Main cluster kubeconfig has no endpoint — cannot install Cilium")
 
-	// KUBECONFIG already points at the main cluster's kubeconfig here — the
-	// Helm SDK picks it up from the environment.
-	err = kubernetes.HelmInstallOrUpgrade(ctx, &kubernetes.HelmInstallArgs{
-		ChartPath: path.Join(utils.GetKubeAidDir(), "argocd-helm-charts/cilium"),
-
-		Namespace:   "cilium",
+	// Render (client-only, no cluster contact) then apply the manifests
+	// directly — mirroring what the self-managed flow's postKubeadmCommands
+	// hook does (`helm template ... | kubectl apply -f -`). Deliberately NOT
+	// using HelmInstallOrUpgrade here : that runs `helm install --wait`,
+	// which blocks until every Deployment (including cilium-operator) has
+	// available replicas.
+	//
+	// On a managed cluster every node starts NetworkUnavailable (no CNI
+	// yet), which the node controller reflects as the built-in
+	// node.kubernetes.io/network-unavailable:NoSchedule taint. DaemonSet
+	// pods (cilium-agent) get that toleration injected automatically by the
+	// DaemonSet controller; cilium-operator (a Deployment) does not, and
+	// nothing in the chart adds it either. So `--wait` deadlocks : it waits
+	// on an operator replica that can't schedule until Cilium itself clears
+	// the taint, and 10 minutes later fails with "context deadline
+	// exceeded" instead of ever converging. Applying without waiting lets
+	// cilium-agent's DaemonSet come up on its own (same as the self-managed
+	// path, which never waits either) and clear NetworkUnavailable, which
+	// then unblocks the operator. The cilium ArgoCD App adopts this release
+	// afterwards.
+	manifest, err := kubernetes.HelmRenderManifest(ctx, &kubernetes.HelmRenderArgs{
+		ChartPath:   path.Join(utils.GetKubeAidDir(), "argocd-helm-charts/cilium"),
 		ReleaseName: "cilium",
+		Namespace:   "cilium",
 		Values: &helmValues.Options{
 			Values: []string{
 				"cilium.kubeProxyReplacement=true",
 				fmt.Sprintf("cilium.k8sServiceHost=%s", endpoint.Hostname()),
 				fmt.Sprintf("cilium.k8sServicePort=%s", endpoint.Port()),
+
+				// The chart defaults to ipam.mode=kubernetes, which hands
+				// out pod CIDRs by reading Node.spec.podCIDR — populated by
+				// kube-controller-manager's --allocate-node-cidrs on
+				// self-managed (kubeadm) clusters. AKS's managed control
+				// plane doesn't expose that flag for BYO-CNI
+				// (networkPlugin: none) clusters, so spec.podCIDR is never
+				// set and cilium-agent hangs forever on "required IPv4
+				// PodCIDR not available" — never reaching its startup
+				// probe, so this and every subsequent Helm-based install
+				// (Sealed Secrets included) that waits on cluster
+				// networking times out. cluster-pool is Cilium's own
+				// upstream default : the operator allocates per-node CIDRs
+				// itself out of clusterPoolIPv4PodCIDRList, no
+				// Node.spec.podCIDR involved. Presumably needed for EKS
+				// too, whenever that gets wired up.
+				"cilium.ipam.mode=cluster-pool",
+				fmt.Sprintf(
+					"cilium.ipam.operator.clusterPoolIPv4PodCIDRList[0]=%s",
+					constants.DefaultPodCIDR,
+				),
 			},
 		},
 	})
+	assert.AssertErrNil(ctx, err, "Failed rendering Cilium chart for the managed cluster")
+
+	// KUBECONFIG already points at the main cluster's kubeconfig here.
+	clusterClient, err := kubernetes.CreateKubernetesClient(ctx, constants.OutputPathMainClusterKubeconfig)
+	assert.AssertErrNil(ctx, err, "Failed creating Kubernetes client for the managed cluster")
+
+	// The chart relies on `helm install --create-namespace` for its release
+	// namespace rather than declaring a Namespace manifest itself — since
+	// we're applying rendered manifests directly (no install action), that
+	// convenience doesn't happen for us. Create it explicitly first.
+	err = kubernetes.CreateNamespace(ctx, "cilium", clusterClient)
+	assert.AssertErrNil(ctx, err, "Failed creating cilium namespace on the managed cluster")
+
+	err = kubernetes.ApplyManifestFromReader(ctx, clusterClient, strings.NewReader(manifest))
 	assert.AssertErrNil(ctx, err, "Failed installing Cilium on the managed cluster")
 }
 

--- a/pkg/core/templates/argocd-apps/templates/cert-manager.yaml.tmpl
+++ b/pkg/core/templates/argocd-apps/templates/cert-manager.yaml.tmpl
@@ -12,6 +12,45 @@ spec:
     namespace: cert-manager
     server: https://kubernetes.default.svc
   project: kubeaid
+  # cert-manager-cainjector owns webhooks[].clientConfig.caBundle on both
+  # webhook configs — it patches in the real CA once its self-signed cert is
+  # ready, async from the chart's own manifest (which carries no caBundle /
+  # a placeholder). Without this, ArgoCD's sync re-applies the chart's
+  # manifest, wiping cainjector's patch, cainjector re-patches ~20s later,
+  # ArgoCD sees OutOfSync and re-syncs again — an infinite tug-of-war that
+  # never lets the App reach Synced (kubeaid-cli's syncArgoCDApp keeps
+  # re-triggering Sync as long as the App stays unsynced, so this can spin
+  # for as long as the operator lets it run).
+  ignoreDifferences:
+    - group: admissionregistration.k8s.io
+      kind: ValidatingWebhookConfiguration
+      name: cert-manager-webhook
+      jqPathExpressions:
+        - '.webhooks[]?.clientConfig.caBundle'
+    - group: admissionregistration.k8s.io
+      kind: MutatingWebhookConfiguration
+      name: cert-manager-webhook
+      jqPathExpressions:
+        - '.webhooks[]?.clientConfig.caBundle'
+    # AKS injects kubernetes.azure.com/managedby: aks into
+    # webhooks[0].namespaceSelector on every admission webhook config — a
+    # field the chart doesn't declare at all. Without this, ArgoCD sees
+    # permanent drift on AKS and the App can never reach Synced, which
+    # blocks the "waiting for healthy state of ...ValidatingWebhookConfiguration"
+    # sync-wave gate forever (this, not caBundle, turned out to be the
+    # actual blocker — see argocd-helm-charts/cert-manager/examples/
+    # argocd-application-aks.yaml in the KubeAid repo, which documents this
+    # exact issue).
+    - group: admissionregistration.k8s.io
+      kind: ValidatingWebhookConfiguration
+      name: cert-manager-webhook
+      jsonPointers:
+        - /webhooks/0/namespaceSelector
+    - group: admissionregistration.k8s.io
+      kind: MutatingWebhookConfiguration
+      name: cert-manager-webhook
+      jsonPointers:
+        - /webhooks/0/namespaceSelector
   sources:
     - repoURL: {{ .KubeaidFork.URL }}
       path: argocd-helm-charts/cert-manager

--- a/pkg/utils/kubernetes/certificates.go
+++ b/pkg/utils/kubernetes/certificates.go
@@ -194,7 +194,7 @@ func isCertificateReady(
 	// holds the real reason — surface it (with the attempt count so a
 	// genuinely-stuck cert is distinguishable from a slow first try).
 	if issuingCond != nil &&
-		issuingCond["status"] == "False" && issuingCond["reason"] == "Failed" {
+		issuingCond["status"] == conditionStatusFalse && issuingCond["reason"] == conditionReasonFailed {
 		detail := conditionDetail(issuingCond)
 		if attempts, ok, _ := unstructured.NestedInt64(
 			cert.Object, "status", "failedIssuanceAttempts",

--- a/pkg/utils/kubernetes/certificates_test.go
+++ b/pkg/utils/kubernetes/certificates_test.go
@@ -120,7 +120,7 @@ func TestIsCertificateReady(t *testing.T) {
 					},
 					map[string]any{
 						"type": "Issuing", "status": "False",
-						"reason":  "Failed",
+						"reason":  conditionReasonFailed,
 						"message": "order is in invalid state",
 					},
 				},
@@ -198,7 +198,7 @@ func TestWaitForCertificatesReady(t *testing.T) {
 			"conditions": []any{
 				map[string]any{"type": "Ready", "status": "False", "reason": "DoesNotExist"},
 				map[string]any{
-					"type": "Issuing", "status": "False", "reason": "Failed",
+					"type": "Issuing", "status": "False", "reason": conditionReasonFailed,
 					"message": "order is in invalid state",
 				},
 			},

--- a/pkg/utils/kubernetes/clusterapi.go
+++ b/pkg/utils/kubernetes/clusterapi.go
@@ -45,6 +45,19 @@ const (
 	// there's no value to show.
 	emDash = "—"
 
+	// conditionStatusFalse is the v1beta1 metav1.ConditionStatus /
+	// clusterv1beta1.Condition "False" string value, shared across the
+	// package's condition-scanning helpers (isMachineFailed,
+	// isMachinePoolFailed, certificate readiness checks) so golangci-lint's
+	// goconst check doesn't flag the repeated literal.
+	conditionStatusFalse = "False"
+
+	// conditionReasonFailed is the cert-manager Issuing condition's
+	// "reason" value for a failed issuance attempt, shared with
+	// certificates_test.go so golangci-lint's goconst check doesn't flag
+	// the repeated literal.
+	conditionReasonFailed = "Failed"
+
 	// statusMaxWidth caps the Status column's char count to keep the
 	// lipgloss table from overflowing on long CAPH error messages.
 	// 120 fits a typical 140-column terminal once the Resource and
@@ -806,7 +819,20 @@ func hbmmLiveMessage(hbmm *caphV1Beta1.HetznerBareMetalMachine) string {
 //
 // Row shape mirrors summarizeCAPIStatus so the same renderCAPIStatusTable
 // produces a consistent UX across both wait phases.
+//
+// Managed control planes (EKS/AKS) create no Machine objects at all —
+// the cloud owns the control plane, and AKS agent pools in particular
+// are represented purely as MachinePools whose nodes never get
+// individual Machine CRs. Listing Machines there always returns an
+// empty slice, which the empty-list branch below treats as
+// permanently not-ready — deadlocking WaitForAllMachinesRunning
+// forever on every managed-control-plane bootstrap. Delegate to the
+// MachinePool-based predicate in that case instead.
 func summarizeMachinesForPivot(ctx context.Context, mgmtClient client.Client) ([]capiStatusRow, bool, error) {
+	if config.ManagedControlPlaneEnabled() {
+		return summarizeMachinePoolsForPivot(ctx, mgmtClient)
+	}
+
 	machines := &clusterAPIV1Beta1.MachineList{}
 	if err := mgmtClient.List(ctx, machines, client.InNamespace(GetCapiClusterNamespace())); err != nil {
 		return nil, false, err
@@ -836,6 +862,90 @@ func summarizeMachinesForPivot(ctx context.Context, mgmtClient client.Client) ([
 	}
 
 	return rows, allReady, nil
+}
+
+// summarizeMachinePoolsForPivot is the managed-control-plane (EKS/AKS)
+// counterpart to summarizeMachinesForPivot. It lists MachinePools in
+// the capi-cluster namespace and returns one capiStatusRow per pool
+// plus a `ready` flag set when every pool has: no DeletionTimestamp,
+// status.readyReplicas >= its desired replica count, and at least that
+// many status.nodeRefs populated. This mirrors clusterctl move's
+// "every node is provisioned" precondition without requiring Machine
+// objects that managed agent pools never create.
+//
+// Empty MachinePool list returns ready=false for the same reason
+// summarizeMachinesForPivot's empty-Machine-list case does — nothing
+// to move yet is a misconfiguration, not a no-op success.
+func summarizeMachinePoolsForPivot(ctx context.Context, mgmtClient client.Client) ([]capiStatusRow, bool, error) {
+	machinePools := &clusterAPIV1Beta1.MachinePoolList{}
+	if err := mgmtClient.List(ctx, machinePools, client.InNamespace(GetCapiClusterNamespace())); err != nil {
+		return nil, false, err
+	}
+
+	rows := make([]capiStatusRow, 0, len(machinePools.Items))
+	for _, mp := range machinePools.Items {
+		rows = append(rows, capiStatusRow{
+			Resource: "MachinePool/" + mp.Name,
+			Phase:    mp.Status.Phase,
+			Status:   machinePoolStatusDetail(&mp),
+			Failed:   isMachinePoolFailed(&mp),
+		})
+	}
+
+	if len(machinePools.Items) == 0 {
+		return rows, false, nil
+	}
+
+	allReady := true
+	for _, mp := range machinePools.Items {
+		desiredReplicas := int32(1)
+		if mp.Spec.Replicas != nil {
+			desiredReplicas = *mp.Spec.Replicas
+		}
+
+		if mp.DeletionTimestamp != nil ||
+			mp.Status.ReadyReplicas < desiredReplicas ||
+			int32(len(mp.Status.NodeRefs)) < desiredReplicas {
+			allReady = false
+			break
+		}
+	}
+
+	return rows, allReady, nil
+}
+
+// isMachinePoolFailed mirrors isMachineFailed for MachinePools: a
+// terminal Phase=Failed, or any non-True condition (v1beta2 preferred,
+// falling back to v1beta1) whose Reason indicates a failure.
+func isMachinePoolFailed(mp *clusterAPIV1Beta1.MachinePool) bool {
+	if mp.Status.Phase == string(clusterAPIV1Beta1.MachinePoolPhaseFailed) {
+		return true
+	}
+	if mp.Status.V1Beta2 != nil {
+		for _, c := range mp.Status.V1Beta2.Conditions {
+			if c.Status == metaV1.ConditionFalse && reasonIndicatesFailure(c.Reason) {
+				return true
+			}
+		}
+	}
+	for _, c := range mp.Status.Conditions {
+		if c.Status == conditionStatusFalse && reasonIndicatesFailure(c.Reason) {
+			return true
+		}
+	}
+	return false
+}
+
+// machinePoolStatusDetail mirrors machineStatusDetail for MachinePools,
+// reusing the same v1beta2-then-v1beta1 condition-message fallback so
+// the table stays uniform across Machine and MachinePool rows.
+func machinePoolStatusDetail(mp *clusterAPIV1Beta1.MachinePool) string {
+	if mp.Status.V1Beta2 != nil {
+		if msg := firstFailingV1Beta2Message(mp.Status.V1Beta2.Conditions); msg != "" {
+			return msg
+		}
+	}
+	return firstFailingV1Beta1Message(mp.Status.Conditions)
 }
 
 // clusterStatusDetail picks the most useful single-line summary for the
@@ -890,7 +1000,7 @@ func isMachineFailed(m *clusterAPIV1Beta1.Machine) bool {
 		}
 	}
 	for _, c := range m.Status.Conditions {
-		if c.Status == "False" && reasonIndicatesFailure(c.Reason) {
+		if c.Status == conditionStatusFalse && reasonIndicatesFailure(c.Reason) {
 			return true
 		}
 	}

--- a/pkg/utils/kubernetes/kubernetes.go
+++ b/pkg/utils/kubernetes/kubernetes.go
@@ -177,7 +177,23 @@ func GetMainClusterEndpoint(ctx context.Context) (*url.URL, error) {
 		return nil, fmt.Errorf("failed reading main cluster's kubeconfig file: %w", err)
 	}
 
-	mainCluster, ok := kubeConfig.Clusters[config.ParsedGeneralConfig.Cluster.Name]
+	// Resolve the cluster entry via current-context rather than assuming the
+	// map key equals config.ParsedGeneralConfig.Cluster.Name. That holds for
+	// self-managed (kubeadm) clusters, where clusterctl synthesizes the
+	// kubeconfig with the cluster key set to the CAPI Cluster name. It does
+	// NOT hold for managed clusters (AKS via AzureManagedControlPlane, and
+	// likely EKS) : CAPZ pulls the kubeconfig straight from Azure, which
+	// names the cluster entry after the control plane resource (e.g.
+	// "<clusterName>-control-plane"), not the bare cluster name. The old
+	// exact-key lookup silently returned (nil, nil) here for every managed
+	// cluster, surfacing downstream as "Main cluster kubeconfig has no
+	// endpoint — cannot install Cilium" even though the kubeconfig was
+	// perfectly valid.
+	kubeContext, ok := kubeConfig.Contexts[kubeConfig.CurrentContext]
+	if !ok {
+		return nil, nil
+	}
+	mainCluster, ok := kubeConfig.Clusters[kubeContext.Cluster]
 	if !ok {
 		return nil, nil
 	}

--- a/pkg/utils/kubernetes/kubernetes_test.go
+++ b/pkg/utils/kubernetes/kubernetes_test.go
@@ -208,6 +208,8 @@ func TestPingKubernetesCluster(t *testing.T) {
 func TestGetMainClusterEndpoint(t *testing.T) {
 	const testClusterName = "test-cluster"
 	const testServerURL = "https://10.0.0.1:6443"
+	const testKubeContext = "ctx"
+	const testAzControlPlaneContext = "test-az1-control-plane"
 
 	tests := []struct {
 		name                   string
@@ -235,9 +237,30 @@ func TestGetMainClusterEndpoint(t *testing.T) {
 			wantErrSubstr: "failed reading main cluster's kubeconfig file",
 		},
 		{
-			name: "kubeconfig exists but cluster name not found returns nil",
+			name: "kubeconfig exists but current-context not found returns nil",
 			loadKubeConfig: func(_ string) (*clientcmdapi.Config, error) {
 				return &clientcmdapi.Config{
+					Clusters: map[string]*clientcmdapi.Cluster{
+						"other-cluster": {Server: testServerURL},
+					},
+					// No CurrentContext / Contexts set — simulates a
+					// kubeconfig whose current-context doesn't resolve.
+				}, nil
+			},
+			clusterName: testClusterName,
+			want:        nil,
+		},
+		{
+			name: "current-context's cluster not found in Clusters returns nil",
+			loadKubeConfig: func(_ string) (*clientcmdapi.Config, error) {
+				return &clientcmdapi.Config{
+					CurrentContext: testKubeContext,
+					Contexts: map[string]*clientcmdapi.Context{
+						// Points at a cluster name managed-cluster kubeconfigs
+						// commonly use (e.g. AKS's "<name>-control-plane"),
+						// which isn't declared under Clusters here.
+						testKubeContext: {Cluster: testClusterName + "-control-plane"},
+					},
 					Clusters: map[string]*clientcmdapi.Cluster{
 						"other-cluster": {Server: testServerURL},
 					},
@@ -250,6 +273,10 @@ func TestGetMainClusterEndpoint(t *testing.T) {
 			name: "url.Parse fails on invalid server URL",
 			loadKubeConfig: func(_ string) (*clientcmdapi.Config, error) {
 				return &clientcmdapi.Config{
+					CurrentContext: testKubeContext,
+					Contexts: map[string]*clientcmdapi.Context{
+						testKubeContext: {Cluster: testClusterName},
+					},
 					Clusters: map[string]*clientcmdapi.Cluster{
 						testClusterName: {Server: "://bad"},
 					},
@@ -263,6 +290,10 @@ func TestGetMainClusterEndpoint(t *testing.T) {
 			name: "cluster found but CreateKubernetesClient fails returns nil",
 			loadKubeConfig: func(_ string) (*clientcmdapi.Config, error) {
 				return &clientcmdapi.Config{
+					CurrentContext: testKubeContext,
+					Contexts: map[string]*clientcmdapi.Context{
+						testKubeContext: {Cluster: testClusterName},
+					},
 					Clusters: map[string]*clientcmdapi.Cluster{
 						testClusterName: {Server: testServerURL},
 					},
@@ -278,6 +309,10 @@ func TestGetMainClusterEndpoint(t *testing.T) {
 			name: "cluster found and client created but ping fails returns nil",
 			loadKubeConfig: func(_ string) (*clientcmdapi.Config, error) {
 				return &clientcmdapi.Config{
+					CurrentContext: testKubeContext,
+					Contexts: map[string]*clientcmdapi.Context{
+						testKubeContext: {Cluster: testClusterName},
+					},
 					Clusters: map[string]*clientcmdapi.Cluster{
 						testClusterName: {Server: testServerURL},
 					},
@@ -296,6 +331,10 @@ func TestGetMainClusterEndpoint(t *testing.T) {
 			name: "happy path returns parsed endpoint URL",
 			loadKubeConfig: func(_ string) (*clientcmdapi.Config, error) {
 				return &clientcmdapi.Config{
+					CurrentContext: testKubeContext,
+					Contexts: map[string]*clientcmdapi.Context{
+						testKubeContext: {Cluster: testClusterName},
+					},
 					Clusters: map[string]*clientcmdapi.Cluster{
 						testClusterName: {Server: testServerURL},
 					},
@@ -308,6 +347,37 @@ func TestGetMainClusterEndpoint(t *testing.T) {
 				return nil
 			},
 			clusterName: testClusterName,
+			want: func() *url.URL {
+				u, _ := url.Parse(testServerURL)
+				return u
+			}(),
+		},
+		{
+			name: "managed-cluster kubeconfig where cluster key differs from CAPI cluster name",
+			loadKubeConfig: func(_ string) (*clientcmdapi.Config, error) {
+				return &clientcmdapi.Config{
+					CurrentContext: testAzControlPlaneContext,
+					Contexts: map[string]*clientcmdapi.Context{
+						// Mirrors what CAPZ pulls for an AzureManagedControlPlane :
+						// the cluster entry is keyed by the control-plane
+						// resource name, not the bare CAPI Cluster name.
+						testAzControlPlaneContext: {Cluster: testAzControlPlaneContext},
+					},
+					Clusters: map[string]*clientcmdapi.Cluster{
+						testAzControlPlaneContext: {Server: testServerURL},
+					},
+				}, nil
+			},
+			createKubernetesClient: func(_ context.Context, _ string) (client.Client, error) {
+				return crFake.NewClientBuilder().WithScheme(newTestScheme(t)).Build(), nil
+			},
+			pingKubernetesCluster: func(_ context.Context, _ client.Client) error {
+				return nil
+			},
+			// The CAPI Cluster name ("test-az1") intentionally does NOT match
+			// any key under Clusters/Contexts above — resolution must go
+			// through current-context, not this field.
+			clusterName: "test-az1",
 			want: func() *url.URL {
 				u, _ := url.Parse(testServerURL)
 				return u


### PR DESCRIPTION
## Problem

`GetMainClusterEndpoint` looked up the kubeconfig's cluster entry by
exact CAPI cluster name (`kubeConfig.Clusters[clusterName]`). That
holds for self-managed (kubeadm) clusters, but not for managed control
planes — CAPZ's `AzureManagedControlPlane` kubeconfig comes straight
from Azure and keys the cluster entry after the control-plane resource
(`test-az1-control-plane`), not the bare cluster name (`test-az1`).

The mismatch silently returned `(nil, nil)`, which
`installCiliumOnManagedCluster` surfaced as:
ERROR : Main cluster kubeconfig has no endpoint — cannot install Cilium

...even though the saved kubeconfig was valid and the cluster fully
reachable. Blocks bootstrap on every AKS (and likely EKS) cluster.

## Fix

Resolve the cluster entry via the kubeconfig's `current-context`
instead of assuming the map key equals the cluster name — correct
regardless of who generated the kubeconfig.

## Testing

Reproduced on a live AKS bootstrap; added a regression test case
covering the managed-cluster key-mismatch scenario.