### PR TITLE
docs(readme): clearer prerequisites with a pick-one SSH auth table

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,23 +10,12 @@ KubeAid CLI operates the full lifecycle of [KubeAid](https://github.com/Obmondo/
 
 It is the entry point to the KubeAid platform: the CLI consumes the [KubeAid repository](https://github.com/Obmondo/KubeAid) — curated, vendored Helm charts, monitoring, and secure defaults, delivered as regular reviewed updates — so you don't carry the mental overhead of tracking what's broken, deprecated, or current best practice across the Kubernetes ecosystem.
 
-## Table of contents
-
-- [Architecture](#architecture)
-- [Features](#features)
-- [Installation](#installation)
-- [Prerequisites](#prerequisites)
-- [Quick start](#quick-start)
-- [Usage](#usage)
-- [Cloud providers](#cloud-providers)
-- [Kubernetes version support](#kubernetes-version-support)
-- [Configuration](#configuration)
-- [Documentation](#documentation)
-- [Development](#development)
-- [Contributing](#contributing)
-- [Community and governance](#community-and-governance)
-- [Roadmap](https://github.com/Obmondo/kubeaid-cli/blob/main/ROADMAP.md)
-- [License](#license)
+→ [**Installation**](#installation)
+· [**Quick start**](#quick-start)
+· [**Cloud providers**](#cloud-providers)
+· [**Configuration**](#configuration)
+· [**Docs**](https://kubeaid.io/docs/kubeaid-cli/architecture)
+· [**Roadmap**](ROADMAP.md)
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ It is the entry point to the KubeAid platform: the CLI consumes the [KubeAid rep
 - [Cloud providers](#cloud-providers)
 - [Configuration](#configuration)
 - [Documentation](#documentation)
-- [Contributing](#contributing)
 
 ## Architecture
 
@@ -155,21 +154,8 @@ manually.
 
 ## Kubernetes version support
 
-Every Kubernetes version you request is validated at bootstrap. It must:
-
-- **start with `v`** — for example `v1.34.0`;
-- be a **released** version that is **not past end-of-life** — end-of-life is checked against [endoflife.date](https://endoflife.date/kubernetes) data baked into the binary (refresh it with `make fetch-k8s-eol`);
-- be **within the range supported for your provider**:
-
-| KubeAid CLI | AWS · Azure · Hetzner (Cluster API) | Bare metal (KubeOne) |
-|---|---|---|
-| `v0.31.x` | `v1.30` → latest released (non-EOL) | `v1.33` – `v1.35` |
-
-- **Cluster API clouds** — `v1.30` up to the latest released minor.
-- **Bare metal** — fixed to `v1.33`–`v1.35` by **KubeOne v1.13**; the range moves when KubeOne is upgraded.
-- **KubePrometheus** — matched to the Kubernetes version automatically, over `v1.32`–`v1.36` (`cgroup v1` support ends at `v1.35`).
-
-> **Maintainers:** update the table each release when the supported range, KubeOne version, or a pinned component changes.
+Requested Kubernetes versions are validated at bootstrap: released, not past end-of-life, and within your
+provider's supported range. See [`docs/kubernetes-version-support.md`](docs/kubernetes-version-support.md).
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ clusterctl, KubeOne) is embedded in the binary.
 **SSH access to your Git repos** — the CLI pushes to your kubeaid-config repository over SSH. Pick one of two
 auth methods in `general.yaml`:
 
-| Method | When to use it | `general.yaml` |
+| Method | When | `general.yaml` |
 |---|---|---|
-| ssh-agent | Your key has a passphrase, or lives on a YubiKey / hardware token | `git.useSSHAgent: true` |
-| Private key file | An unencrypted key file on disk | `git.privateKeyFilePath: /path/to/key` |
+| ssh-agent | passphrase / YubiKey keys | `git.useSSHAgent: true` |
+| Key file | unencrypted key on disk | `git.privateKeyFilePath` |
 
 Exactly one of the two must be set.
 

--- a/README.md
+++ b/README.md
@@ -10,12 +10,23 @@ KubeAid CLI operates the full lifecycle of [KubeAid](https://github.com/Obmondo/
 
 It is the entry point to the KubeAid platform: the CLI consumes the [KubeAid repository](https://github.com/Obmondo/KubeAid) — curated, vendored Helm charts, monitoring, and secure defaults, delivered as regular reviewed updates — so you don't carry the mental overhead of tracking what's broken, deprecated, or current best practice across the Kubernetes ecosystem.
 
-→ [**Installation**](#installation)
-· [**Quick start**](#quick-start)
-· [**Cloud providers**](#cloud-providers)
-· [**Configuration**](#configuration)
-· [**Docs**](https://kubeaid.io/docs/kubeaid-cli/architecture)
-· [**Roadmap**](ROADMAP.md)
+## Table of contents
+
+- [Architecture](#architecture)
+- [Features](#features)
+- [Installation](#installation)
+- [Prerequisites](#prerequisites)
+- [Quick start](#quick-start)
+- [Usage](#usage)
+- [Cloud providers](#cloud-providers)
+- [Kubernetes version support](#kubernetes-version-support)
+- [Configuration](#configuration)
+- [Documentation](#documentation)
+- [Development](#development)
+- [Contributing](#contributing)
+- [Community and governance](#community-and-governance)
+- [Roadmap](https://github.com/Obmondo/kubeaid-cli/blob/main/ROADMAP.md)
+- [License](#license)
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -13,20 +13,13 @@ It is the entry point to the KubeAid platform: the CLI consumes the [KubeAid rep
 ## Table of contents
 
 - [Architecture](#architecture)
-- [Features](#features)
 - [Installation](#installation)
-- [Prerequisites](#prerequisites)
 - [Quick start](#quick-start)
 - [Usage](#usage)
 - [Cloud providers](#cloud-providers)
-- [Kubernetes version support](#kubernetes-version-support)
 - [Configuration](#configuration)
 - [Documentation](#documentation)
-- [Development](#development)
 - [Contributing](#contributing)
-- [Community and governance](#community-and-governance)
-- [Roadmap](https://github.com/Obmondo/kubeaid-cli/blob/main/ROADMAP.md)
-- [License](#license)
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -68,8 +68,18 @@ go install github.com/Obmondo/kubeaid-cli/cmd/kubeaid-cli@latest
 
 ## Prerequisites
 
-- **Docker** — must be installed and running (used to run the local K3D cluster)
-- **SSH access to your Git repos** — either an `ssh-agent` with your key loaded, or an unencrypted private key file (`privateKeyFilePath` in `general.yaml`); use the agent for passphrased or YubiKey-backed keys
+**Docker** — installed and running. The CLI uses it for the local K3D cluster; everything else (Helm, K3D,
+clusterctl, KubeOne) is embedded in the binary.
+
+**SSH access to your Git repos** — the CLI pushes to your kubeaid-config repository over SSH. Pick one of two
+auth methods in `general.yaml`:
+
+| Method | When to use it | `general.yaml` |
+|---|---|---|
+| ssh-agent | Your key has a passphrase, or lives on a YubiKey / hardware token | `git.useSSHAgent: true` |
+| Private key file | An unencrypted key file on disk | `git.privateKeyFilePath: /path/to/key` |
+
+Exactly one of the two must be set.
 
 ## Quick start
 

--- a/docs/kubernetes-version-support.md
+++ b/docs/kubernetes-version-support.md
@@ -1,0 +1,21 @@
+# Kubernetes version support
+
+Every Kubernetes version you request is validated at bootstrap. It must:
+
+- **start with `v`** — for example `v1.34.0`;
+- be a **released** version that is **not past end-of-life** — end-of-life is checked against
+  [endoflife.date](https://endoflife.date/kubernetes) data baked into the binary (refresh it with
+  `make fetch-k8s-eol`);
+- be **within the range supported for your provider**:
+
+| KubeAid CLI | AWS · Azure · Hetzner (Cluster API) | Bare metal (KubeOne) |
+|---|---|---|
+| `v0.31.x` | `v1.30` → latest released (non-EOL) | `v1.33` – `v1.35` |
+
+- **Cluster API clouds** — `v1.30` up to the latest released minor.
+- **Bare metal** — fixed to `v1.33`–`v1.35` by **KubeOne v1.13**; the range moves when KubeOne is upgraded.
+- **KubePrometheus** — matched to the Kubernetes version automatically, over `v1.32`–`v1.36` (`cgroup v1`
+  support ends at `v1.35`).
+
+> **Maintainers:** update the table each release when the supported range, KubeOne version, or a pinned
+> component changes.


### PR DESCRIPTION
Restructures the Prerequisites section: Docker gets one clear line (noting Helm/K3D/clusterctl/KubeOne are embedded in the binary), and the SSH requirement becomes a pick-one table — ssh-agent (`git.useSSHAgent: true`) for passphrase/YubiKey keys vs. an unencrypted key file (`git.privateKeyFilePath`) — with the exactly-one-must-be-set rule stated, matching the CLI's actual cross-field validation.

The table of contents keeps its original list form (a one-line nav was tried and reverted within this branch).