### PR TITLE
feat(kubeaid-agent): follow the vulnerability-scanning answer for the…

### DIFF
--- a/pkg/core/templates/argocd-apps/values-kubeaid-agent.yaml.tmpl
+++ b/pkg/core/templates/argocd-apps/values-kubeaid-agent.yaml.tmpl
@@ -2,3 +2,16 @@
 appConfig:
   kubeaidConfig:
     clusterName: {{ .ClusterConfig.Name }}
+
+# The security exporter follows the vulnerability-scanning answer rather than a
+# switch of its own. It reads what that answer deploys: trivy-operator's report
+# CRs are its primary source, and version-checker is what turns a finding into
+# an upgrade. Saying no leaves it out instead of running a collector with
+# nothing to collect.
+#
+# backup-exporter is deliberately absent, and stays absent. It needs S3
+# credentials and a bucket for every backend it reports on, so enabling it is a
+# manual, per-cluster act in that cluster's own values file -- not something the
+# CLI decides. Emitting nothing here leaves the chart's default (off) standing.
+securityExporter:
+  enabled: {{ .ClusterConfig.Security.VulnerabilityScanning }}


### PR DESCRIPTION
… exporter

Renders securityExporter.enabled into the cluster's values-kubeaid-agent.yaml from cluster.security.vulnerabilityScanning -- the answer the operator already gives -- rather than introducing a switch of its own.

The exporter reads what that answer deploys: trivy-operator's report CRs are its primary source, and version-checker is what turns a finding into an applicable upgrade. Tying the two means saying no leaves the exporter out instead of running a collector with nothing to collect, and means there is one place the decision lives rather than two that can disagree.

backup-exporter is deliberately not rendered here at all. Every backend it covers needs S3 credentials and a bucket, so turning it on is a manual, per-cluster act in that cluster's values file, not something the CLI decides. Emitting nothing leaves the chart's default -- off -- standing.

Rendered against both answers to confirm the emitted value follows.