### PR TITLE
fix(kubeaid-agent): use the subchart's values key for the security ex…

### DIFF
--- a/pkg/core/templates/argocd-apps/values-kubeaid-agent.yaml.tmpl
+++ b/pkg/core/templates/argocd-apps/values-kubeaid-agent.yaml.tmpl
@@ -13,5 +13,11 @@ appConfig:
 # credentials and a bucket for every backend it reports on, so enabling it is a
 # manual, per-cluster act in that cluster's own values file -- not something the
 # CLI decides. Emitting nothing here leaves the chart's default (off) standing.
-securityExporter:
+#
+# The key is the SUBCHART's name, not camelCase. Both exporters are local
+# subcharts of kubeaid-agent, and Helm keys subchart values by chart name, so
+# "securityExporter" would be silently ignored -- the subchart default (on)
+# would apply and a cluster that declined scanning would get the exporter
+# anyway.
+security-exporter:
   enabled: {{ .ClusterConfig.Security.VulnerabilityScanning }}


### PR DESCRIPTION
…porter

KubeAid moved both exporters into local subcharts of kubeaid-agent, and Helm keys subchart values by chart name. The key this template emitted, securityExporter, no longer matches anything.

It fails in the worst direction. An unknown key is not an error: it is ignored, the subchart's own default (enabled: true) applies, and a cluster that answered no to vulnerability scanning gets the exporter deployed anyway -- the opposite of what its operator asked for, with nothing failing to say so.

Rendered against both answers and parsed the result to confirm the key now lands as security-exporter.enabled.