### PR TITLE
monitoring: check and auto-fix Prometheus scrape-namespace RBAC gaps

### DIFF
--- a/cmd/kubeaid-core/root/monitoring/check_scrape_namespaces.go
+++ b/cmd/kubeaid-core/root/monitoring/check_scrape_namespaces.go
@@ -1,0 +1,34 @@
+// Copyright 2026 Obmondo
+// SPDX-License-Identifier: Apache-2.0
+
+package monitoring
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/Obmondo/kubeaid-cli/pkg/core"
+)
+
+var CheckScrapeNamespacesCmd = &cobra.Command{
+	Use: "check-scrape-namespaces",
+
+	Short: "Find namespaces with a PodMonitor/ServiceMonitor but missing prometheus-k8s RBAC",
+
+	Long: `Lists every namespace that has a PodMonitor or ServiceMonitor but no
+"prometheus-k8s" Role granting Prometheus list/watch access to it.
+
+A namespace in this state was left out of prometheus_scrape_namespaces in the
+cluster's kube-prometheus *-vars.jsonnet: Prometheus discovers the monitor
+object fine, but is Forbidden from listing/watching pods or services in that
+namespace, which fires PrometheusKubernetesListWatchFailures permanently
+until the namespace is added there and kube-prometheus is rebuilt.
+
+Runs against whatever cluster your current kubeconfig context points at,
+exactly like kubectl.`,
+
+	Args: cobra.NoArgs,
+
+	Run: func(cmd *cobra.Command, args []string) {
+		core.MonitoringScrapeNamespacesCheck(cmd.Context())
+	},
+}

--- a/cmd/kubeaid-core/root/monitoring/fix_scrape_namespaces.go
+++ b/cmd/kubeaid-core/root/monitoring/fix_scrape_namespaces.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Obmondo
+// SPDX-License-Identifier: Apache-2.0
+
+package monitoring
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	configSetup "github.com/Obmondo/kubeaid-cli/pkg/config/setup"
+	"github.com/Obmondo/kubeaid-cli/pkg/core"
+	"github.com/Obmondo/kubeaid-cli/pkg/utils"
+)
+
+var FixScrapeNamespacesCmd = &cobra.Command{
+	Use: "fix-scrape-namespaces",
+
+	Short: "Add any namespace missing prometheus-k8s RBAC to prometheus_scrape_namespaces",
+
+	Long: `Runs the same check as "check-scrape-namespaces", and for every namespace it
+finds, appends it to prometheus_scrape_namespaces in this cluster's
+*-vars.jsonnet and rebuilds the kube-prometheus manifests.
+
+Unlike "check-scrape-namespaces", this needs the cluster's config and the
+KubeAid / KubeAid Config repos on disk (same as "cluster bootstrap"/"cluster
+upgrade"), since it edits and rebuilds from those repos rather than just
+querying the live cluster - so, unlike every other "monitoring" subcommand,
+it takes --cluster-name/--configs-directory.
+
+Only touches the local working tree: review the diff, then commit and push
+yourself so ArgoCD picks it up. This is the standalone equivalent of the fix
+"cluster bootstrap"/"cluster upgrade" already run automatically at the end of
+every bootstrap or upgrade - use this to fix an existing cluster without
+having to re-run one of those.`,
+
+	Args: cobra.NoArgs,
+
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		prepareMonitoringFixCommand(cmd.Context())
+	},
+
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := cmd.Context()
+
+		missing, err := core.CheckPrometheusScrapeNamespaces(ctx)
+		if err != nil {
+			slog.ErrorContext(ctx, "Failed checking Prometheus scrape-namespace RBAC",
+				slog.Any("err", err))
+			os.Exit(1)
+		}
+
+		if len(missing) == 0 {
+			fmt.Println( //nolint:forbidigo // operator-facing terminal output
+				"OK: every namespace with a PodMonitor/ServiceMonitor has prometheus-k8s RBAC.",
+			)
+			return
+		}
+
+		if err := core.AddMissingScrapeNamespaces(ctx, missing); err != nil {
+			slog.ErrorContext(ctx, "Failed adding missing scrape namespaces",
+				slog.Any("namespaces", missing), slog.Any("err", err))
+			os.Exit(1)
+		}
+
+		fmt.Printf( //nolint:forbidigo // operator-facing terminal output
+			"Added to prometheus_scrape_namespaces and regenerated kube-prometheus manifests: %v\n"+
+				"Review the diff, then commit and push so ArgoCD picks it up.\n",
+			missing,
+		)
+	},
+}
+
+// prepareMonitoringFixCommand mirrors cluster.prepareClusterCommand: parses the cluster config
+// and sets up the temp dir. Needed here (and only here, among monitoring's subcommands) because
+// AddMissingScrapeNamespaces edits files in the KubeAid Config repo clone and reruns the
+// kube-prometheus builder from the KubeAid repo clone, both resolved via ParsedGeneralConfig -
+// check-scrape-namespaces only ever talks to the live cluster, so it doesn't need any of this.
+func prepareMonitoringFixCommand(ctx context.Context) {
+	if err := configSetup.Prepare(ctx); err != nil {
+		slog.ErrorContext(ctx, "Failed preparing config files", slog.Any("err", err))
+		os.Exit(1)
+	}
+
+	if err := utils.InitTempDir(ctx); err != nil {
+		slog.ErrorContext(ctx, "Failed initializing temp dir", slog.Any("err", err))
+		os.Exit(1)
+	}
+}

--- a/cmd/kubeaid-core/root/monitoring/monitoring.go
+++ b/cmd/kubeaid-core/root/monitoring/monitoring.go
@@ -1,0 +1,22 @@
+// Copyright 2026 Obmondo
+// SPDX-License-Identifier: Apache-2.0
+
+package monitoring
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// MonitoringCmd only groups monitoring subcommands; like backup, it has no
+// PersistentPreRun of its own, so most subcommands run without any parsed
+// cluster config. FixScrapeNamespacesCmd is the one exception - see its own
+// PersistentPreRun for why it needs one.
+var MonitoringCmd = &cobra.Command{
+	Use:   "monitoring",
+	Short: "Inspect monitoring health of a KubeAid managed K8s cluster",
+}
+
+func init() {
+	MonitoringCmd.AddCommand(CheckScrapeNamespacesCmd)
+	MonitoringCmd.AddCommand(FixScrapeNamespacesCmd)
+}

--- a/cmd/kubeaid-core/root/root.go
+++ b/cmd/kubeaid-core/root/root.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Obmondo/kubeaid-cli/cmd/kubeaid-core/root/cluster"
 	"github.com/Obmondo/kubeaid-cli/cmd/kubeaid-core/root/config"
 	"github.com/Obmondo/kubeaid-cli/cmd/kubeaid-core/root/devenv"
+	"github.com/Obmondo/kubeaid-cli/cmd/kubeaid-core/root/monitoring"
 	"github.com/Obmondo/kubeaid-cli/cmd/kubeaid-core/root/version"
 	"github.com/Obmondo/kubeaid-cli/pkg/config/clusterdir"
 	"github.com/Obmondo/kubeaid-cli/pkg/constants"
@@ -143,6 +144,7 @@ func init() {
 	RootCmd.AddCommand(config.ConfigCmd)
 	RootCmd.AddCommand(devenv.DevenvCmd)
 	RootCmd.AddCommand(backup.BackupCmd)
+	RootCmd.AddCommand(monitoring.MonitoringCmd)
 	RootCmd.AddCommand(cluster.ClusterCmd)
 	RootCmd.AddCommand(version.VersionCommand)
 

--- a/pkg/config/parser/k8s-eol.json
+++ b/pkg/config/parser/k8s-eol.json
@@ -1,5 +1,14 @@
 [
   {
+    "cycle": "1.37",
+    "releaseDate": "2026-08-26",
+    "eol": "2027-10-28",
+    "latest": "1.37.0",
+    "latestReleaseDate": "2026-08-26",
+    "lts": false,
+    "support": "2027-08-28"
+  },
+  {
     "cycle": "1.36",
     "releaseDate": "2026-04-22",
     "eol": "2027-06-28",

--- a/pkg/core/monitoring_scrape_guard.go
+++ b/pkg/core/monitoring_scrape_guard.go
@@ -1,0 +1,114 @@
+// Copyright 2026 Obmondo
+// SPDX-License-Identifier: Apache-2.0
+
+package core
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/Obmondo/kubeaid-cli/pkg/utils/assert"
+	"github.com/Obmondo/kubeaid-cli/pkg/utils/kubernetes"
+)
+
+var (
+	podMonitorGVR = schema.GroupVersionResource{
+		Group: "monitoring.coreos.com", Version: "v1", Resource: "podmonitors",
+	}
+	serviceMonitorGVR = schema.GroupVersionResource{
+		Group: "monitoring.coreos.com", Version: "v1", Resource: "servicemonitors",
+	}
+)
+
+// prometheusRBACRoleName is the Role/RoleBinding name kube-prometheus's jsonnet build renders
+// into every namespace listed in prometheus_scrape_namespaces (see KubeAid's
+// build/kube-prometheus/common-template.jsonnet). A namespace missing that Role is a namespace
+// Prometheus can't list/watch pods or services in, regardless of whether a PodMonitor/
+// ServiceMonitor exists there.
+const prometheusRBACRoleName = "prometheus-k8s"
+
+// CheckPrometheusScrapeNamespaces reports every namespace that has a PodMonitor or
+// ServiceMonitor but no "prometheus-k8s" Role granting Prometheus access to it.
+//
+// prometheus_scrape_namespaces is a hand-maintained list in each cluster's *-vars.jsonnet, with
+// nothing enforcing that it still covers every namespace an addon has since started dropping a
+// PodMonitor/ServiceMonitor into. Left out, the gap is silent at deploy time and only surfaces
+// later as a permanent PrometheusKubernetesListWatchFailures alert (Forbidden on list/watch) -
+// this check catches it before that, against whatever the live cluster's RBAC actually grants.
+func CheckPrometheusScrapeNamespaces(ctx context.Context) ([]string, error) {
+	restConfig, err := kubernetes.CreateRESTConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	dynamicClient, err := dynamic.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed creating dynamic client: %w", err)
+	}
+
+	clientset, err := kubernetes.CreateClientset(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	monitoredNamespaces := map[string]struct{}{}
+	for _, gvr := range []schema.GroupVersionResource{podMonitorGVR, serviceMonitorGVR} {
+		list, err := dynamicClient.Resource(gvr).Namespace(metaV1.NamespaceAll).
+			List(ctx, metaV1.ListOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("failed listing %s: %w", gvr.Resource, err)
+		}
+		for _, item := range list.Items {
+			monitoredNamespaces[item.GetNamespace()] = struct{}{}
+		}
+	}
+
+	roles, err := clientset.RbacV1().Roles(metaV1.NamespaceAll).List(ctx, metaV1.ListOptions{
+		FieldSelector: "metadata.name=" + prometheusRBACRoleName,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed listing %s Roles: %w", prometheusRBACRoleName, err)
+	}
+	scrapableNamespaces := map[string]struct{}{}
+	for _, role := range roles.Items {
+		scrapableNamespaces[role.Namespace] = struct{}{}
+	}
+
+	missing := make([]string, 0, len(monitoredNamespaces))
+	for namespace := range monitoredNamespaces {
+		if _, ok := scrapableNamespaces[namespace]; !ok {
+			missing = append(missing, namespace)
+		}
+	}
+	sort.Strings(missing)
+	return missing, nil
+}
+
+// MonitoringScrapeNamespacesCheck runs CheckPrometheusScrapeNamespaces against the current
+// kubeconfig context and prints the result, for the "monitoring check-scrape-namespaces"
+// command.
+func MonitoringScrapeNamespacesCheck(ctx context.Context) {
+	missing, err := CheckPrometheusScrapeNamespaces(ctx)
+	assert.AssertErrNil(ctx, err, "Failed checking Prometheus scrape namespace RBAC")
+
+	if len(missing) == 0 {
+		fmt.Println( //nolint:forbidigo // operator-facing terminal output
+			"OK: every namespace with a PodMonitor/ServiceMonitor has prometheus-k8s RBAC.",
+		)
+		return
+	}
+
+	fmt.Println( //nolint:forbidigo // operator-facing terminal output
+		"Namespaces with a PodMonitor/ServiceMonitor but missing prometheus-k8s RBAC " +
+			"(add them to prometheus_scrape_namespaces in this cluster's *-vars.jsonnet and " +
+			"rebuild kube-prometheus):",
+	)
+	for _, namespace := range missing {
+		fmt.Printf("  - %s\n", namespace) //nolint:forbidigo // operator-facing terminal output
+	}
+}

--- a/pkg/core/monitoring_scrape_writer.go
+++ b/pkg/core/monitoring_scrape_writer.go
@@ -1,0 +1,122 @@
+// Copyright 2026 Obmondo
+// SPDX-License-Identifier: Apache-2.0
+
+package core
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/Obmondo/kubeaid-cli/pkg/config"
+	"github.com/Obmondo/kubeaid-cli/pkg/constants"
+	"github.com/Obmondo/kubeaid-cli/pkg/utils"
+)
+
+// scrapeNamespacesFieldPattern matches the prometheus_scrape_namespaces list in a
+// *-vars.jsonnet file, capturing its (possibly empty, possibly multi-line) contents between the
+// brackets. Tolerates both the freshly-generated "[]" shape (see cluster-vars.jsonnet.tmpl) and
+// a hand-edited multi-line list (one quoted namespace per line, as every existing cluster's vars
+// file already has it).
+var scrapeNamespacesFieldPattern = regexp.MustCompile(
+	`(?s)(prometheus_scrape_namespaces:\s*\[)(.*?)(\])`,
+)
+
+// quotedStringPattern matches a single- or double-quoted jsonnet string literal, capturing its
+// contents. jsonnet accepts both quote styles and this codebase uses both across clusters (e.g.
+// double-quoted on master's vpn-vars.jsonnet, single-quoted on the hetzner-qa branch's) - this is
+// how existing list entries are read back regardless of which one a given file uses.
+var quotedStringPattern = regexp.MustCompile(`["']([^"']*)["']`)
+
+// AddMissingScrapeNamespaces appends any namespace missing prometheus-k8s RBAC to
+// prometheus_scrape_namespaces in the cluster's *-vars.jsonnet, then regenerates the
+// kube-prometheus manifests from that updated file.
+//
+// This is a surgical text edit of the EXISTING file, not a call to buildKubePrometheus /
+// createFileFromTemplate — that path opens the destination with O_TRUNC and rewrites it from
+// cluster-vars.jsonnet.tmpl unconditionally, which would silently wipe out every hand-edit an
+// operator has made to the file since initial bootstrap (ingress hosts, resource limits,
+// connect_obmondo, previously-added scrape namespaces, ...). Regenerating just the
+// kube-prometheus/ manifests via runKubePrometheusBuilder is safe on repeat calls: it only
+// derives output from the vars.jsonnet that's now on disk.
+//
+// Deliberately does NOT commit or push - this only touches the operator's local working tree.
+// Publishing the change (review the diff, commit, push, let ArgoCD sync it) is left to the
+// operator, same as any other GitOps change; kubeaid-cli doesn't push to a customer's config
+// repo unattended.
+func AddMissingScrapeNamespaces(ctx context.Context, missing []string) error {
+	clusterDir := utils.GetClusterDir()
+	jsonnetVarsFilePath := fmt.Sprintf(
+		"%s/%s-vars.jsonnet",
+		clusterDir,
+		config.ParsedGeneralConfig.Cluster.Name,
+	)
+
+	original, err := os.ReadFile(jsonnetVarsFilePath)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", jsonnetVarsFilePath, err)
+	}
+
+	updated, changed, err := insertScrapeNamespaces(string(original), missing)
+	if err != nil {
+		return fmt.Errorf("updating prometheus_scrape_namespaces in %s: %w", jsonnetVarsFilePath, err)
+	}
+	if !changed {
+		return nil
+	}
+
+	//nolint:gosec // vars.jsonnet is operator-authored config, not a secret - 0o644 matches its
+	// existing on-disk permissions.
+	if err := os.WriteFile(jsonnetVarsFilePath, []byte(updated), 0o644); err != nil {
+		return fmt.Errorf("writing %s: %w", jsonnetVarsFilePath, err)
+	}
+
+	kubeAidDir := utils.GetKubeAidDir()
+	if err := runKubePrometheusBuilder(
+		ctx, os.Getuid(), os.Getgid(), kubeAidDir, clusterDir, constants.KubePromBuilderImage,
+	); err != nil {
+		return fmt.Errorf("regenerating kube-prometheus manifests: %w", err)
+	}
+
+	return nil
+}
+
+// insertScrapeNamespaces returns vars.jsonnet's content with any namespace in missing that isn't
+// already present appended to the prometheus_scrape_namespaces list, and whether it changed
+// anything (namespaces already listed are left as-is, so this is safe to call repeatedly).
+func insertScrapeNamespaces(content string, missing []string) (string, bool, error) {
+	match := scrapeNamespacesFieldPattern.FindStringSubmatchIndex(content)
+	if match == nil {
+		return "", false, fmt.Errorf("prometheus_scrape_namespaces field not found")
+	}
+
+	existingBlock := content[match[4]:match[5]]
+
+	existing := map[string]bool{}
+	for _, submatch := range quotedStringPattern.FindAllStringSubmatch(existingBlock, -1) {
+		existing[submatch[1]] = true
+	}
+
+	var toAdd []string
+	for _, namespace := range missing {
+		if !existing[namespace] {
+			toAdd = append(toAdd, namespace)
+		}
+	}
+	if len(toAdd) == 0 {
+		return content, false, nil
+	}
+
+	var newEntries strings.Builder
+	for _, namespace := range toAdd {
+		fmt.Fprintf(&newEntries, "\n    %q,", namespace)
+	}
+
+	trimmedBlock := strings.TrimRight(existingBlock, " \t\n")
+	replacement := trimmedBlock + newEntries.String() + "\n  "
+
+	updated := content[:match[4]] + replacement + content[match[5]:]
+	return updated, true, nil
+}

--- a/pkg/core/monitoring_scrape_writer_test.go
+++ b/pkg/core/monitoring_scrape_writer_test.go
@@ -1,0 +1,172 @@
+// Copyright 2026 Obmondo
+// SPDX-License-Identifier: Apache-2.0
+
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddScrapeNamespaces(t *testing.T) {
+	testCases := []struct {
+		name    string
+		content string
+		missing []string
+
+		expectChanged bool
+		expectErr     bool
+		expectContain []string // substrings that must appear in the result
+	}{
+		{
+			name: "empty list, matches cluster-vars.jsonnet.tmpl's freshly-generated shape",
+			content: `{
+  platform: "kubeadm",
+  prometheus_scrape_namespaces: [],
+  prometheus_scrape_default_namespaces: [
+    "argocd",
+  ],
+}
+`,
+			missing:       []string{"openobserve"},
+			expectChanged: true,
+			expectContain: []string{`"openobserve"`},
+		},
+		{
+			// The shape every real *-vars.jsonnet file we've seen actually has, once an
+			// operator has hand-edited it (e.g. k8s/vpn/vpn-vars.jsonnet).
+			name: "multi-line hand-edited list, matches real vpn-vars.jsonnet shape",
+			content: `{
+  prometheus_scrape_namespaces: [
+    "cloudnative-pg",
+    "external-dns",
+    "netbird",
+    "keycloakx",
+  ],
+  prometheus_scrape_default_namespaces: [
+    "argocd",
+    "sealed-secrets",
+    "cert-manager",
+  ],
+}
+`,
+			missing:       []string{"velero"},
+			expectChanged: true,
+			expectContain: []string{`"cloudnative-pg"`, `"external-dns"`, `"netbird"`, `"keycloakx"`, `"velero"`},
+		},
+		{
+			name: "namespace already listed is left alone and reported unchanged",
+			content: `{
+  prometheus_scrape_namespaces: [
+    "netbird",
+  ],
+}
+`,
+			missing:       []string{"netbird"},
+			expectChanged: false,
+		},
+		{
+			// This codebase uses both quote styles across clusters (double-quoted on master's
+			// vpn-vars.jsonnet, single-quoted on the hetzner-qa branch's) - an existing
+			// single-quoted entry must still be recognised, or this would insert a duplicate.
+			name: "namespace already listed with single quotes is recognised, not duplicated",
+			content: `{
+  prometheus_scrape_namespaces: [
+    'argocd',
+    'netbird',
+  ],
+}
+`,
+			missing:       []string{"netbird"},
+			expectChanged: false,
+		},
+		{
+			name: "only the genuinely-missing namespace out of several is added",
+			content: `{
+  prometheus_scrape_namespaces: [
+    "netbird",
+  ],
+}
+`,
+			missing:       []string{"netbird", "velero"},
+			expectChanged: true,
+			expectContain: []string{`"netbird"`, `"velero"`},
+		},
+		{
+			name: "doesn't touch prometheus_scrape_default_namespaces",
+			content: `{
+  prometheus_scrape_namespaces: [
+    "netbird",
+  ],
+  prometheus_scrape_default_namespaces: [
+    "argocd",
+  ],
+}
+`,
+			missing:       []string{"velero"},
+			expectChanged: true,
+			expectContain: []string{`"velero"`},
+		},
+		{
+			name: "field not found is an error, not a silent no-op",
+			content: `{
+  platform: "kubeadm",
+}
+`,
+			missing:   []string{"velero"},
+			expectErr: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			updated, changed, err := insertScrapeNamespaces(testCase.content, testCase.missing)
+
+			if testCase.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, testCase.expectChanged, changed)
+
+			if !testCase.expectChanged {
+				assert.Equal(t, testCase.content, updated)
+				return
+			}
+			for _, substr := range testCase.expectContain {
+				assert.Contains(t, updated, substr)
+			}
+
+			// The result must still be a valid-looking bracketed list (every entry between
+			// the same "prometheus_scrape_namespaces: [" ... "]" pair) - regression guard
+			// against the regex accidentally spilling past the closing bracket into
+			// prometheus_scrape_default_namespaces or another field.
+			match := scrapeNamespacesFieldPattern.FindStringSubmatch(updated)
+			require.NotNil(t, match)
+			for _, ns := range testCase.missing {
+				assert.Contains(t, match[2], ns)
+			}
+		})
+	}
+}
+
+// Re-running the fix against its own output must be a no-op the second time - a repeat
+// bootstrap/upgrade shouldn't grow the list every time it runs.
+func TestAddScrapeNamespaces_Idempotent(t *testing.T) {
+	content := `{
+  prometheus_scrape_namespaces: [
+    "netbird",
+  ],
+}
+`
+	once, changed, err := insertScrapeNamespaces(content, []string{"velero"})
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	twice, changedAgain, err := insertScrapeNamespaces(once, []string{"velero"})
+	require.NoError(t, err)
+	assert.False(t, changedAgain)
+	assert.Equal(t, once, twice)
+}

--- a/pkg/core/setup_cluster.go
+++ b/pkg/core/setup_cluster.go
@@ -400,7 +400,50 @@ func SetupCluster(ctx context.Context, args SetupClusterArgs) {
 		bar.Substep("Synced capi-cluster ArgoCD app")
 	}
 
+	// kube-prometheus is workload-only (see the root sync filter above), so this has nothing to
+	// check on the management cluster.
+	if args.ClusterType != constants.ClusterTypeManagement {
+		fixScrapeNamespacesIfNeeded(ctx)
+	}
+
 	printHelpTextForArgoCDDashboardAccess(ctx, args.ClusterType)
+}
+
+// fixScrapeNamespacesIfNeeded catches any namespace that has a PodMonitor/ServiceMonitor but is
+// missing from prometheus_scrape_namespaces in this cluster's *-vars.jsonnet, right after
+// SetupCluster's ArgoCD sync - instead of it only surfacing later as a permanent
+// PrometheusKubernetesListWatchFailures alert. A static, pre-deploy scan of the config repo can't
+// be trusted to find every such namespace (an app's ServiceMonitor may live on a not-yet-merged
+// branch, or the app may not be GitOps-managed at all), so this runs against what's actually live.
+// Non-fatal: bootstrap has already succeeded by this point.
+func fixScrapeNamespacesIfNeeded(ctx context.Context) {
+	missingScrapeNamespaces, err := CheckPrometheusScrapeNamespaces(ctx)
+	if err != nil {
+		slog.WarnContext(ctx,
+			"Skipping Prometheus scrape-namespace RBAC check", slog.Any("err", err),
+		)
+		return
+	}
+	if len(missingScrapeNamespaces) == 0 {
+		return
+	}
+
+	if err := AddMissingScrapeNamespaces(ctx, missingScrapeNamespaces); err != nil {
+		slog.WarnContext(ctx,
+			"Namespaces with a PodMonitor/ServiceMonitor but missing prometheus-k8s RBAC - "+
+				"add them to prometheus_scrape_namespaces in this cluster's *-vars.jsonnet "+
+				"and rebuild kube-prometheus",
+			slog.Any("namespaces", missingScrapeNamespaces),
+			slog.Any("auto_fix_err", err),
+		)
+		return
+	}
+
+	slog.WarnContext(ctx,
+		"Added missing prometheus-k8s RBAC namespaces to *-vars.jsonnet and regenerated "+
+			"kube-prometheus manifests - review the diff, commit, and push so ArgoCD picks it up",
+		slog.Any("namespaces", missingScrapeNamespaces),
+	)
 }
 
 // Syncs the Infrastructure Provider component of the CAPI Cluster ArgoCD App and waits for the


### PR DESCRIPTION
Closes #85

## Summary
- `kubeaid monitoring check-scrape-namespaces` finds every namespace with a PodMonitor/ServiceMonitor but no `prometheus-k8s` Role.
- `kubeaid monitoring fix-scrape-namespaces` runs that check standalone and applies the fix directly — needs `--cluster-name`/`--configs-directory` (unlike the other monitoring subcommands) since it edits and rebuilds from the cloned config/KubeAid repos, not just the live cluster.
- Both are also wired into `SetupCluster`'s post-bootstrap step (skipped on the management cluster), so a bootstrap/upgrade catches the gap automatically too.
- The fix itself (`AddMissingScrapeNamespaces`) surgically appends the missing namespace(s) to the existing `*-vars.jsonnet` and reruns the kube-prometheus builder — doesn't regenerate the whole file (would wipe hand-edits), doesn't commit/push (left to the operator).
