### PR TITLE
feat(aws): let a cluster name the ~/.aws profile its credentials come…

### DIFF
--- a/cmd/kubeaid-core/root/config/templates/secrets.yaml
+++ b/cmd/kubeaid-core/root/config/templates/secrets.yaml
@@ -1,4 +1,16 @@
 aws:
+  # Profile names the ~/.aws/{config,credentials} profile the
+  # credentials for this cluster are resolved from. Set it when the
+  # machine carries several AWS accounts and the SDK default profile
+  # is not the right one. Leave the key fields blank alongside it —
+  # they are filled in from the profile at parse time. Machine-local
+  # (profile names differ per operator), which is why it lives here
+  # and not in general.yaml.
+  profile:
+  # AWSAccessKeyID, AWSSecretAccessKey and AWSSessionToken are the
+  # resolved credentials. Supply them directly to bypass ~/.aws
+  # entirely; otherwise leave them blank and they are resolved from
+  # Profile (or the SDK default profile when Profile is empty).
   accessKeyID:
   secretAccessKey:
   sessionToken:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -394,6 +394,29 @@ flowchart TD
 - [pkg/config/secrets.go](../pkg/config/secrets.go) - `SecretsConfig` struct tree.
 - [pkg/config/parser/](../pkg/config/parser) - orchestrates parse → defaults → validate → hydrate (`parse.go`, `validate.go`, …).
 
+### 6.1 AWS credential resolution
+
+`secrets.yaml` can name a `~/.aws` profile instead of carrying keys, so a machine that manages several AWS accounts does not have to have its `~/.aws/config` rewritten per cluster:
+
+```yaml
+aws:
+  profile: acme-prod
+```
+
+Resolution order, in `hydrateAWSCredentials` ([`pkg/config/parser/parse.go`](../pkg/config/parser/parse.go)):
+
+1. `accessKeyID` / `secretAccessKey` / `sessionToken` spelled out in `secrets.yaml` win outright.
+2. Otherwise the credentials are read from `aws.profile` in `~/.aws`.
+3. With neither, the SDK's own default resolution applies (`AWS_PROFILE`, `[default]`, instance role, …).
+
+`config generate` fills `aws.profile` in: it lists the profiles across `~/.aws/config` and `~/.aws/credentials` and, when there is more than one, asks which account this cluster belongs to (with "enter credentials manually" as the way out). A lone profile that isn't `default` is recorded too, since the SDK would otherwise look for a `[default]` section that doesn't exist.
+
+When there is no profile to use — no `~/.aws`, or the operator chose to type keys in — the credential inputs are seeded from `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN`, blanks only, so values recovered from an existing `secrets.yaml` still win. They are prefilled rather than accepted silently because environment variables last one shell session while `cluster bootstrap` needs the credentials on every later run, so they have to be confirmed into `secrets.yaml`. A config never ends up carrying both a profile and keys: the keys would win at bootstrap, making the profile a lie.
+
+Every AWS SDK client is built through `awsCloudProvider.LoadSDKConfig` ([`pkg/cloud/aws/aws.go`](../pkg/cloud/aws/aws.go)), which pins the selected profile via `WithSharedConfigProfile`. `SetAWSSpecificEnvs` also exports `AWS_PROFILE`, so the embedded `clusterawsadm` commands — which build their own SDK config — read the same profile's shared config as the rest of the run, and a stale profile inherited from the operator's shell is cleared.
+
+Their *credentials* come from the static keys exported alongside it. Worth knowing when reasoning about this: an `AWS_PROFILE` env var does **not** outrank `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`. `resolveCredentialChain` only takes the profile branch when the profile was set programmatically (it inspects the `LoadOptions`, not the `EnvConfig`), so env-var credentials win over an env-var profile — but lose to `WithSharedConfigProfile`.
+
 **Top-level `GeneralConfig` fields:**
 
 | Field            | Purpose                                                       |

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -175,7 +175,8 @@ NOTE : Generally, refer to the KubeadmControlPlane CRD instead of the correspond
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| accessKeyID | `string` |  |  |
+| profile | `string` |  | Profile names the ~/.aws/{config,credentials} profile the<br>credentials for this cluster are resolved from. Set it when the<br>machine carries several AWS accounts and the SDK default profile<br>is not the right one. Leave the key fields blank alongside it —<br>they are filled in from the profile at parse time. Machine-local<br>(profile names differ per operator), which is why it lives here<br>and not in general.yaml.<br> |
+| accessKeyID | `string` |  | AWSAccessKeyID, AWSSecretAccessKey and AWSSessionToken are the<br>resolved credentials. Supply them directly to bypass ~/.aws<br>entirely; otherwise leave them blank and they are resolved from<br>Profile (or the SDK default profile when Profile is empty).<br> |
 | secretAccessKey | `string` |  |  |
 | sessionToken | `string` |  |  |
 

--- a/pkg/cloud/aws/aws.go
+++ b/pkg/cloud/aws/aws.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/Obmondo/kubeaid-cli/pkg/cloud"
 	"github.com/Obmondo/kubeaid-cli/pkg/cloud/aws/services"
+	"github.com/Obmondo/kubeaid-cli/pkg/config"
 )
 
 type AWS struct {
@@ -23,9 +24,31 @@ type AWS struct {
 	ec2Client ec2DescribeInstanceTypesAPI
 }
 
-var loadAWSConfig = func(ctx context.Context) (aws.Config, error) {
-	return awsSDKGoV2Config.LoadDefaultConfig(ctx)
+// SelectedProfile returns the ~/.aws profile chosen in secrets.yaml
+// (aws.profile), or "" when the SDK's own default resolution applies.
+func SelectedProfile() string {
+	if config.ParsedSecretsConfig == nil || config.ParsedSecretsConfig.AWS == nil {
+		return ""
+	}
+
+	return config.ParsedSecretsConfig.AWS.Profile
 }
+
+// LoadSDKConfig builds an AWS SDK config, pinned to the profile selected in
+// secrets.yaml when there is one. Every AWS SDK client in kubeaid-cli is built
+// from this, so that on a machine carrying several AWS accounts we talk to the
+// account the cluster belongs to rather than the SDK's default profile.
+func LoadSDKConfig(ctx context.Context) (aws.Config, error) {
+	var options []func(*awsSDKGoV2Config.LoadOptions) error
+
+	if profile := SelectedProfile(); profile != "" {
+		options = append(options, awsSDKGoV2Config.WithSharedConfigProfile(profile))
+	}
+
+	return awsSDKGoV2Config.LoadDefaultConfig(ctx, options...)
+}
+
+var loadAWSConfig = LoadSDKConfig
 
 func NewAWSCloudProvider() (cloud.CloudProvider, error) {
 	ctx := context.Background()

--- a/pkg/cloud/aws/set_aws_specific_envs.go
+++ b/pkg/cloud/aws/set_aws_specific_envs.go
@@ -41,6 +41,7 @@ func SetAWSSpecificEnvs(ctx context.Context) error {
 	utils.MustSetEnv(constants.EnvNameAWSSecretKey, awsCredentials.AWSSecretAccessKey)
 	utils.MustSetEnv(constants.EnvNameAWSSessionToken, awsCredentials.AWSSessionToken)
 	utils.MustSetEnv(constants.EnvNameAWSRegion, config.ParsedGeneralConfig.Cloud.AWS.Region)
+	utils.MustSetEnv(constants.EnvNameAWSProfile, awsCredentials.Profile)
 
 	credentialsCmdOutput, err := executeCredentialsCmd(ctx)
 	if err != nil {

--- a/pkg/cloud/aws/set_aws_specific_envs_test.go
+++ b/pkg/cloud/aws/set_aws_specific_envs_test.go
@@ -23,12 +23,14 @@ func TestSetAWSSpecificEnvs(t *testing.T) {
 		constants.EnvNameAWSSecretKey,
 		constants.EnvNameAWSSessionToken,
 		constants.EnvNameAWSRegion,
+		constants.EnvNameAWSProfile,
 		constants.EnvNameAWSB64EcodedCredentials,
 	}
 
 	tests := []struct {
 		name    string
 		stub    func(ctx context.Context) (string, error)
+		profile string
 		wantErr bool
 		errMsg  string
 		wantB64 string
@@ -39,6 +41,18 @@ func TestSetAWSSpecificEnvs(t *testing.T) {
 				return "WARNING: `encode-as-profile` should only be used for bootstrapping.\n  base64credentials  \n", nil
 			},
 			wantB64: "base64credentials",
+		},
+		{
+			// The embedded clusterawsadm commands build their own SDK config,
+			// so the selected profile has to reach them for the shared config
+			// they read, and an inherited one has to be cleared when none is
+			// selected.
+			name: "exports the selected profile",
+			stub: func(_ context.Context) (string, error) {
+				return "rawcredentials", nil
+			},
+			profile: "work",
+			wantB64: "rawcredentials",
 		},
 		{
 			name: "sets env vars when output has no warning prefix",
@@ -82,8 +96,13 @@ func TestSetAWSSpecificEnvs(t *testing.T) {
 				}
 			})
 
+			// Left over from the developer's shell or a previous cluster, this
+			// must not survive into the clusterawsadm commands.
+			require.NoError(t, os.Setenv(constants.EnvNameAWSProfile, "inherited"))
+
 			config.ParsedSecretsConfig = &config.SecretsConfig{
 				AWS: &config.AWSCredentials{
+					Profile:            tc.profile,
 					AWSAccessKeyID:     "aws-access-key",
 					AWSSecretAccessKey: "aws-secret-key",
 					AWSSessionToken:    "test-session-token",
@@ -110,6 +129,7 @@ func TestSetAWSSpecificEnvs(t *testing.T) {
 			assert.Equal(t, "aws-secret-key", os.Getenv(constants.EnvNameAWSSecretKey))
 			assert.Equal(t, "test-session-token", os.Getenv(constants.EnvNameAWSSessionToken))
 			assert.Equal(t, "eu-west-1", os.Getenv(constants.EnvNameAWSRegion))
+			assert.Equal(t, tc.profile, os.Getenv(constants.EnvNameAWSProfile))
 			assert.Equal(t, tc.wantB64, os.Getenv(constants.EnvNameAWSB64EcodedCredentials))
 		})
 	}

--- a/pkg/cloud/aws/utils.go
+++ b/pkg/cloud/aws/utils.go
@@ -7,13 +7,12 @@ import (
 	"context"
 	"fmt"
 
-	awsSDKGoV2Config "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/cmd/clusterawsadm/cmd/bootstrap/iam"
 )
 
 var getCallerIdentity = func(ctx context.Context) (*sts.GetCallerIdentityOutput, error) {
-	awsSDKConfig, err := awsSDKGoV2Config.LoadDefaultConfig(ctx)
+	awsSDKConfig, err := LoadSDKConfig(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("initiating AWS SDK config: %w", err)
 	}

--- a/pkg/config/parser/aws_credentials_test.go
+++ b/pkg/config/parser/aws_credentials_test.go
@@ -1,0 +1,100 @@
+// Copyright 2026 Obmondo
+// SPDX-License-Identifier: Apache-2.0
+
+package parser
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Obmondo/kubeaid-cli/pkg/config"
+)
+
+// writeAWSCredentialsFile writes a shared-credentials file with two
+// static-credential profiles and points the SDK at it. Static credentials
+// resolve entirely from the file, so no AWS call is made.
+//
+// The path goes through AWS_SHARED_CREDENTIALS_FILE rather than a fake HOME :
+// the SDK derives its default ~/.aws paths into package-level vars at init, so
+// a HOME set afterwards is never consulted.
+func writeAWSCredentialsFile(t *testing.T) {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "credentials")
+	require.NoError(t, os.WriteFile(path, []byte(`[default]
+aws_access_key_id = AKIADEFAULT
+aws_secret_access_key = default-secret
+
+[work]
+aws_access_key_id = AKIAWORK
+aws_secret_access_key = work-secret
+aws_session_token = work-token
+`), 0o600))
+
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", path)
+	// Nothing from the developer's shell may steer resolution.
+	t.Setenv("AWS_CONFIG_FILE", filepath.Join(t.TempDir(), "config"))
+	t.Setenv("AWS_PROFILE", "")
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+	t.Setenv("AWS_SESSION_TOKEN", "")
+}
+
+// hydrateAWSCredentials is what makes issue #87's `aws.profile` mean anything :
+// it is the one place where "which AWS account is this cluster in" is settled.
+func TestHydrateAWSCredentials(t *testing.T) {
+	tests := []struct {
+		name             string
+		secrets          *config.AWSCredentials
+		wantAccessKeyID  string
+		wantSecretKey    string
+		wantSessionToken string
+	}{
+		{
+			name:            "no aws block falls back to the SDK default profile",
+			secrets:         nil,
+			wantAccessKeyID: "AKIADEFAULT",
+			wantSecretKey:   "default-secret",
+		},
+		{
+			name:             "a named profile is read instead of the default one",
+			secrets:          &config.AWSCredentials{Profile: "work"},
+			wantAccessKeyID:  "AKIAWORK",
+			wantSecretKey:    "work-secret",
+			wantSessionToken: "work-token",
+		},
+		{
+			name: "explicit credentials win over the profile",
+			secrets: &config.AWSCredentials{
+				Profile:            "work",
+				AWSAccessKeyID:     "AKIAEXPLICIT",
+				AWSSecretAccessKey: "explicit-secret",
+			},
+			wantAccessKeyID: "AKIAEXPLICIT",
+			wantSecretKey:   "explicit-secret",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			writeAWSCredentialsFile(t)
+
+			saved := config.ParsedSecretsConfig
+			t.Cleanup(func() { config.ParsedSecretsConfig = saved })
+			config.ParsedSecretsConfig = &config.SecretsConfig{AWS: tc.secrets}
+
+			hydrateAWSCredentials(context.Background())
+
+			got := config.ParsedSecretsConfig.AWS
+			require.NotNil(t, got)
+			assert.Equal(t, tc.wantAccessKeyID, got.AWSAccessKeyID)
+			assert.Equal(t, tc.wantSecretKey, got.AWSSecretAccessKey)
+			assert.Equal(t, tc.wantSessionToken, got.AWSSessionToken)
+		})
+	}
+}

--- a/pkg/config/parser/parse.go
+++ b/pkg/config/parser/parse.go
@@ -13,7 +13,6 @@ import (
 	"slices"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	awsConfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/creasty/defaults"
 	"gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/util/version"
@@ -113,19 +112,11 @@ func ParseConfigFiles(ctx context.Context, configsDirectory string) {
 		err = yaml.Unmarshal([]byte(secretsConfigFileContents), config.ParsedSecretsConfig)
 		assert.AssertErrNil(ctx, err, "Failed unmarshalling secrets config")
 
-		// The AWS credentials and region were not provided via the config file.
-		// We'll retrieve them using the files in ~/.aws.
-		// And we panic on failure.
+		// Any AWS credentials the config file didn't carry are retrieved from
+		// the files in ~/.aws. And we panic on failure.
 
-		if (globals.CloudProviderName == constants.CloudProviderAWS) &&
-			(config.ParsedSecretsConfig.AWS == nil) {
-			awsCredentials := mustGetCredentialsFromAWSConfigFile(ctx)
-
-			config.ParsedSecretsConfig.AWS = &config.AWSCredentials{
-				AWSAccessKeyID:     awsCredentials.AccessKeyID,
-				AWSSecretAccessKey: awsCredentials.SecretAccessKey,
-				AWSSessionToken:    awsCredentials.SessionToken,
-			}
+		if globals.CloudProviderName == constants.CloudProviderAWS {
+			hydrateAWSCredentials(ctx)
 		}
 
 		// Auto-generate any required-but-blank random secrets
@@ -276,12 +267,40 @@ func setCloudProvider(ctx context.Context) {
 	}
 }
 
+// hydrateAWSCredentials fills the AWS credentials in the secrets config from
+// the files in ~/.aws, unless secrets.yaml already carries them. The profile
+// read is aws.profile, or the SDK default profile when that is unset.
+// Panics on any error.
+func hydrateAWSCredentials(ctx context.Context) {
+	if config.ParsedSecretsConfig.AWS == nil {
+		config.ParsedSecretsConfig.AWS = &config.AWSCredentials{}
+	}
+	awsSecrets := config.ParsedSecretsConfig.AWS
+
+	// Credentials spelled out in secrets.yaml win — nothing to resolve.
+	if awsSecrets.AWSAccessKeyID != "" {
+		return
+	}
+
+	awsCredentials := mustGetCredentialsFromAWSConfigFile(ctx)
+
+	awsSecrets.AWSAccessKeyID = awsCredentials.AccessKeyID
+	awsSecrets.AWSSecretAccessKey = awsCredentials.SecretAccessKey
+	awsSecrets.AWSSessionToken = awsCredentials.SessionToken
+}
+
 // Retrieve AWS credentials using the files in ~/.aws.
 // Panics on any error.
 func mustGetCredentialsFromAWSConfigFile(ctx context.Context) *aws.Credentials {
-	slog.InfoContext(ctx, "Trying to pickup AWS credentials from ~/.aws/config")
+	profile := awsCloudProvider.SelectedProfile()
+	if profile == "" {
+		profile = "(SDK default)"
+	}
+	slog.InfoContext(ctx, "Trying to pickup AWS credentials from ~/.aws/config",
+		slog.String("profile", profile),
+	)
 
-	awsConfig, err := awsConfig.LoadDefaultConfig(ctx)
+	awsConfig, err := awsCloudProvider.LoadSDKConfig(ctx)
 	assert.AssertErrNil(ctx, err, "Failed constructing AWS config using files in ~/.aws")
 
 	awsCredentials, err := awsConfig.Credentials.Retrieve(ctx)

--- a/pkg/config/prompt/provider_aws.go
+++ b/pkg/config/prompt/provider_aws.go
@@ -12,11 +12,14 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/charmbracelet/huh"
+
+	"github.com/Obmondo/kubeaid-cli/pkg/constants"
 )
 
 // Canonical's unauthenticated simplestreams index for released AWS images.
@@ -214,37 +217,253 @@ func newAWSProvider() *awsPrompter {
 }
 
 func (p *awsPrompter) SummaryLines(cfg *PromptedConfig) []string {
+	var lines []string
+
+	// Only shown when a profile was actually chosen — an empty one means the
+	// SDK's default resolution, which there is nothing to report about.
+	if cfg.AWSProfile != "" {
+		lines = append(lines, fmt.Sprintf("  Profile:       %s", cfg.AWSProfile))
+	}
+
 	if cfg.AWSEKS {
-		return []string{
+		return append(lines,
 			fmt.Sprintf("  Region:        %s", cfg.AWSRegion),
 			"  Control plane: EKS (managed by AWS)",
-		}
+		)
 	}
-	return []string{
+
+	return append(lines,
 		fmt.Sprintf("  Region:        %s", cfg.AWSRegion),
 		fmt.Sprintf("  Instance type: %s", cfg.AWSCPInstanceType),
 		fmt.Sprintf("  CP replicas:   %s", cfg.AWSCPReplicas),
-	}
+	)
 }
 
-// detectAWSCredentials reports whether AWS credentials are reachable via
-// ~/.aws files. On success it also returns the path where they were found.
-func detectAWSCredentials() (source string, ok bool) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", false
+// awsSharedCredentialsFilePath and awsSharedConfigFilePath return the two
+// ~/.aws file locations, honouring the SDK's overrides so a direnv-style setup
+// pointing elsewhere is still read.
+func awsSharedCredentialsFilePath() string {
+	if override := os.Getenv(constants.EnvNameAWSSharedCredentialsFile); override != "" {
+		return override
 	}
 
-	for _, candidate := range []string{
-		filepath.Join(home, ".aws", "credentials"),
-		filepath.Join(home, ".aws", "config"),
-	} {
-		if _, err := os.Stat(candidate); err == nil {
-			return candidate, true
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+
+	return filepath.Join(home, ".aws", "credentials")
+}
+
+func awsSharedConfigFilePath() string {
+	if override := os.Getenv(constants.EnvNameAWSConfigFile); override != "" {
+		return override
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+
+	return filepath.Join(home, ".aws", "config")
+}
+
+// awsINISectionRegexp captures the body of an ini section header.
+var awsINISectionRegexp = regexp.MustCompile(`^\s*\[([^\]]+)\]`)
+
+// parseAWSProfileNames extracts the profile names from one ~/.aws file.
+// In config, profiles are "[profile foo]" plus a bare "[default]", and the
+// other section kinds (sso-session, services) are not profiles; in
+// credentials, every section "[foo]" is a profile.
+func parseAWSProfileNames(contents string, isConfigFile bool) []string {
+	var names []string
+
+	for _, line := range strings.Split(contents, "\n") {
+		match := awsINISectionRegexp.FindStringSubmatch(line)
+		if match == nil {
+			continue
+		}
+
+		section := strings.TrimSpace(match[1])
+
+		if isConfigFile {
+			if section != "default" && !strings.HasPrefix(section, "profile ") {
+				continue
+			}
+			section = strings.TrimSpace(strings.TrimPrefix(section, "profile "))
+		}
+
+		// Profile names containing spaces are quoted in the ini files.
+		section = strings.Trim(section, `"'`)
+
+		if section != "" {
+			names = append(names, section)
 		}
 	}
 
-	return "", false
+	return names
+}
+
+// detectAWSProfiles lists the profiles configured across ~/.aws/config and
+// ~/.aws/credentials, sorted and de-duplicated.
+func detectAWSProfiles() []string {
+	seen := map[string]bool{}
+	profiles := []string{}
+
+	for _, file := range []struct {
+		path     string
+		isConfig bool
+	}{
+		{awsSharedConfigFilePath(), true},
+		{awsSharedCredentialsFilePath(), false},
+	} {
+		if file.path == "" {
+			continue
+		}
+
+		contents, err := os.ReadFile(file.path)
+		if err != nil {
+			continue
+		}
+
+		for _, name := range parseAWSProfileNames(string(contents), file.isConfig) {
+			if seen[name] {
+				continue
+			}
+			seen[name] = true
+			profiles = append(profiles, name)
+		}
+	}
+
+	sort.Strings(profiles)
+
+	return profiles
+}
+
+// preferredAWSProfile picks which profile the selection prompt starts on :
+// whatever AWS_PROFILE already names, else "default", else the first listed.
+func preferredAWSProfile(profiles []string) string {
+	if len(profiles) == 0 {
+		return ""
+	}
+
+	for _, candidate := range []string{os.Getenv(constants.EnvNameAWSProfile), "default"} {
+		if candidate != "" && slices.Contains(profiles, candidate) {
+			return candidate
+		}
+	}
+
+	return profiles[0]
+}
+
+// prefillAWSCredentialsFromEnv seeds the credential inputs from the SDK's own
+// environment variables, so an operator who already has them exported confirms
+// them instead of retyping. Only blanks are filled : values recovered from an
+// existing secrets.yaml are the operator's stated choice and win.
+//
+// They are prefilled rather than accepted silently because env vars live for
+// one shell session, while `cluster bootstrap` needs the credentials on every
+// later run — so they have to reach secrets.yaml.
+func prefillAWSCredentialsFromEnv(cfg *PromptedConfig) {
+	before := cfg.AWSAccessKeyID
+
+	cfg.AWSAccessKeyID = firstNonEmpty(
+		cfg.AWSAccessKeyID, os.Getenv(constants.EnvNameAWSAccessKey),
+	)
+	cfg.AWSSecretAccessKey = firstNonEmpty(
+		cfg.AWSSecretAccessKey, os.Getenv(constants.EnvNameAWSSecretKey),
+	)
+	cfg.AWSSessionToken = firstNonEmpty(
+		cfg.AWSSessionToken, os.Getenv(constants.EnvNameAWSSessionToken),
+	)
+
+	if before == "" && cfg.AWSAccessKeyID != "" {
+		slog.Info("Prefilled the AWS credentials from the environment — confirm them to store them")
+	}
+}
+
+// manualAWSCredentialsChoice is the sentinel index the profile select uses for
+// "type the keys in instead". Profile options carry their index in the list,
+// so it can't collide with one.
+const manualAWSCredentialsChoice = -1
+
+// chooseAWSProfile settles where this cluster's AWS credentials come from,
+// before anything else asks for them.
+//
+// It returns whether the credential inputs still need to be shown, seeding them
+// from the environment when they do. cfg.AWSProfile is left empty when the
+// SDK's own default resolution is the right answer — nothing configured, or a
+// lone "default" profile.
+//
+// A config never ends up carrying both a profile and keys : at bootstrap the
+// keys would win, so the profile would be a lie.
+func chooseAWSProfile(cfg *PromptedConfig) (promptForKeys bool, err error) {
+	profiles := detectAWSProfiles()
+
+	switch {
+	case len(profiles) == 0:
+		// Nothing in ~/.aws to pick from. Drop any profile carried over from a
+		// previous run — it no longer resolves to anything.
+		slog.Info("No AWS profiles found in ~/.aws — prompting for credentials")
+		cfg.AWSProfile = ""
+		prefillAWSCredentialsFromEnv(cfg)
+
+		return true, nil
+
+	case len(profiles) == 1:
+		// One profile, no question to ask. It gets named only when it would
+		// actually be used : not when the config already carries keys (they
+		// win), and not when it is "default" (which the SDK resolves anyway).
+		if profiles[0] != "default" && cfg.AWSAccessKeyID == "" {
+			cfg.AWSProfile = profiles[0]
+		}
+		slog.Info("Using the only AWS profile found in ~/.aws",
+			slog.String("profile", profiles[0]),
+		)
+
+		return false, nil
+	}
+
+	options := make([]huh.Option[int], 0, len(profiles)+1)
+	for i, profile := range profiles {
+		options = append(options, huh.NewOption(profile, i))
+	}
+	options = append(options,
+		huh.NewOption("Enter credentials manually", manualAWSCredentialsChoice),
+	)
+
+	selected := slices.Index(profiles, firstNonEmpty(cfg.AWSProfile, preferredAWSProfile(profiles)))
+	if selected < 0 {
+		selected = 0
+	}
+
+	if err := huh.NewForm(
+		huh.NewGroup(
+			huh.NewSelect[int]().
+				Title("AWS profile to use for this cluster:").
+				Description("Found several profiles in ~/.aws — the chosen one is stored in secrets.yaml.").
+				Options(options...).
+				Value(&selected),
+		).Title("AWS credentials").Description("Step 3/4 (cont.)"),
+	).Run(); err != nil {
+		return false, err
+	}
+
+	if selected == manualAWSCredentialsChoice {
+		cfg.AWSProfile = ""
+		prefillAWSCredentialsFromEnv(cfg)
+
+		return true, nil
+	}
+
+	cfg.AWSProfile = profiles[selected]
+	// The chosen profile is now the source of truth, so keys carried over from
+	// a previous run must go — they would otherwise win over it at bootstrap.
+	cfg.AWSAccessKeyID = ""
+	cfg.AWSSecretAccessKey = ""
+	cfg.AWSSessionToken = ""
+
+	return false, nil
 }
 
 func (p *awsPrompter) RunCredentialsForm(cfg *PromptedConfig, _ *autoDetectedConfig) error {
@@ -278,6 +497,14 @@ func (p *awsPrompter) RunCredentialsForm(cfg *PromptedConfig, _ *autoDetectedCon
 		return err
 	}
 
+	// Where the credentials come from is settled before we decide whether to
+	// ask for keys : on a machine carrying several AWS accounts, the SDK's
+	// default profile is rarely the account this cluster belongs to.
+	promptForKeys, err := chooseAWSProfile(cfg)
+	if err != nil {
+		return err
+	}
+
 	haChoice := cfg.AWSCPReplicas != "1"
 
 	credGroup := huh.NewGroup(
@@ -293,15 +520,7 @@ func (p *awsPrompter) RunCredentialsForm(cfg *PromptedConfig, _ *autoDetectedCon
 		huh.NewInput().
 			Title("Session Token (leave empty if not needed):").
 			Value(&cfg.AWSSessionToken),
-	)
-
-	if source, ok := detectAWSCredentials(); ok {
-		slog.Info("Using existing AWS credentials", slog.String("source", source))
-		// Hide the credential inputs — SDK will pick them up automatically.
-		credGroup = credGroup.WithHide(true)
-	} else {
-		slog.Info("No AWS credentials found in ~/.aws — prompting")
-	}
+	).WithHide(!promptForKeys)
 
 	haGroup := huh.NewGroup(
 		huh.NewConfirm().
@@ -312,7 +531,7 @@ func (p *awsPrompter) RunCredentialsForm(cfg *PromptedConfig, _ *autoDetectedCon
 		return cfg.AWSEKS
 	})
 
-	err := huh.NewForm(
+	err = huh.NewForm(
 		credGroup,
 		haGroup.Title("AWS credentials").Description("Step 3/4 (cont.)"),
 	).Run()

--- a/pkg/config/prompt/provider_aws_test.go
+++ b/pkg/config/prompt/provider_aws_test.go
@@ -44,6 +44,34 @@ func TestAWSPrompter_SummaryLines(t *testing.T) {
 				"  CP replicas:   ",
 			},
 		},
+		{
+			name: "a chosen profile is reported first",
+			cfg: &PromptedConfig{
+				AWSProfile:        "work",
+				AWSRegion:         "eu-west-1",
+				AWSCPInstanceType: "t3.medium",
+				AWSCPReplicas:     "3",
+			},
+			want: []string{
+				"  Profile:       work",
+				"  Region:        eu-west-1",
+				"  Instance type: t3.medium",
+				"  CP replicas:   3",
+			},
+		},
+		{
+			name: "EKS with a chosen profile",
+			cfg: &PromptedConfig{
+				AWSProfile: "work",
+				AWSEKS:     true,
+				AWSRegion:  "eu-west-1",
+			},
+			want: []string{
+				"  Profile:       work",
+				"  Region:        eu-west-1",
+				"  Control plane: EKS (managed by AWS)",
+			},
+		},
 	}
 
 	p := newAWSProvider()
@@ -54,62 +82,316 @@ func TestAWSPrompter_SummaryLines(t *testing.T) {
 	}
 }
 
-func TestDetectAWSCredentials(t *testing.T) {
+func TestParseAWSProfileNames(t *testing.T) {
 	tests := []struct {
-		name      string
-		setupHome func(t *testing.T) string
-		wantOK    bool
-		wantBase  string
+		name         string
+		contents     string
+		isConfigFile bool
+		want         []string
 	}{
 		{
-			name: "credentials file is detected",
-			setupHome: func(t *testing.T) string {
-				home := t.TempDir()
-				require.NoError(t, os.MkdirAll(filepath.Join(home, ".aws"), 0o700))
-				require.NoError(t, os.WriteFile(
-					filepath.Join(home, ".aws", "credentials"),
-					[]byte("[default]\n"),
-					0o600,
-				))
-				return home
-			},
-			wantOK:   true,
-			wantBase: "credentials",
+			name: "config file: default plus prefixed profiles",
+			contents: strings.Join([]string{
+				"[default]",
+				"region = eu-west-1",
+				"[profile staging]",
+				"region = eu-central-1",
+				"  [profile prod]  ",
+				"region = us-east-1",
+			}, "\n"),
+			isConfigFile: true,
+			want:         []string{"default", "staging", "prod"},
 		},
 		{
-			name: "config file is detected when credentials missing",
-			setupHome: func(t *testing.T) string {
-				home := t.TempDir()
-				require.NoError(t, os.MkdirAll(filepath.Join(home, ".aws"), 0o700))
-				require.NoError(t, os.WriteFile(
-					filepath.Join(home, ".aws", "config"),
-					[]byte("[default]\nregion=eu-west-1\n"),
-					0o600,
-				))
-				return home
-			},
-			wantOK:   true,
-			wantBase: "config",
+			name: "config file: non-profile sections are skipped",
+			contents: strings.Join([]string{
+				"[sso-session corp]",
+				"sso_region = eu-west-1",
+				"[services localstack]",
+				"[profile staging]",
+			}, "\n"),
+			isConfigFile: true,
+			want:         []string{"staging"},
 		},
 		{
-			name: "no AWS files means not detected",
-			setupHome: func(t *testing.T) string {
-				return t.TempDir()
-			},
-			wantOK: false,
+			// Without the `profile ` prefix, `[staging]` in config is not a
+			// profile the SDK would resolve — only `[default]` is.
+			name:         "config file: a bare section is not a profile",
+			contents:     "[staging]\n[default]\n",
+			isConfigFile: true,
+			want:         []string{"default"},
+		},
+		{
+			name:         "credentials file: every section is a profile",
+			contents:     "[default]\naws_access_key_id = A\n\n[work]\naws_access_key_id = B\n",
+			isConfigFile: false,
+			want:         []string{"default", "work"},
+		},
+		{
+			name:         "quoted profile names are unquoted",
+			contents:     "[profile \"two words\"]\n",
+			isConfigFile: true,
+			want:         []string{"two words"},
+		},
+		{
+			name:         "comments and blank lines are ignored",
+			contents:     "# [profile commented]\n\n; another comment\n[profile real]\n",
+			isConfigFile: true,
+			want:         []string{"real"},
+		},
+		{
+			name:         "empty file yields nothing",
+			contents:     "",
+			isConfigFile: true,
+			want:         nil,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			home := tc.setupHome(t)
-			t.Setenv("HOME", home)
+			assert.Equal(t, tc.want, parseAWSProfileNames(tc.contents, tc.isConfigFile))
+		})
+	}
+}
 
-			source, ok := detectAWSCredentials()
-			assert.Equal(t, tc.wantOK, ok)
-			if tc.wantOK {
-				assert.Equal(t, tc.wantBase, filepath.Base(source))
+// writeAWSFiles points HOME at a temp dir and writes the given ~/.aws files
+// into it. An empty string means "don't write this file".
+func writeAWSFiles(t *testing.T, configContents, credentialsContents string) {
+	t.Helper()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// Nothing from the developer's shell may leak into the decision.
+	t.Setenv("AWS_CONFIG_FILE", "")
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", "")
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+	t.Setenv("AWS_SESSION_TOKEN", "")
+
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".aws"), 0o700))
+
+	for name, contents := range map[string]string{
+		"config":      configContents,
+		"credentials": credentialsContents,
+	} {
+		if contents == "" {
+			continue
+		}
+		require.NoError(t, os.WriteFile(
+			filepath.Join(home, ".aws", name), []byte(contents), 0o600,
+		))
+	}
+}
+
+func TestDetectAWSProfiles(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      string
+		credentials string
+		want        []string
+	}{
+		{
+			name: "no AWS files means no profiles",
+			want: []string{},
+		},
+		{
+			name:   "single default profile",
+			config: "[default]\nregion = eu-west-1\n",
+			want:   []string{"default"},
+		},
+		{
+			name:   "several profiles are sorted",
+			config: "[default]\n[profile staging]\n[profile prod]\n",
+			want:   []string{"default", "prod", "staging"},
+		},
+		{
+			name:        "profiles from both files are merged and de-duplicated",
+			config:      "[default]\n[profile staging]\n",
+			credentials: "[default]\n[work]\n",
+			want:        []string{"default", "staging", "work"},
+		},
+		{
+			name:        "credentials-only setup is picked up",
+			credentials: "[personal]\n[work]\n",
+			want:        []string{"personal", "work"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			writeAWSFiles(t, tc.config, tc.credentials)
+
+			assert.Equal(t, tc.want, detectAWSProfiles())
+		})
+	}
+}
+
+func TestPreferredAWSProfile(t *testing.T) {
+	tests := []struct {
+		name     string
+		profiles []string
+		envVar   string
+		want     string
+	}{
+		{
+			name:     "AWS_PROFILE wins when it is one of the profiles",
+			profiles: []string{"default", "prod", "staging"},
+			envVar:   "prod",
+			want:     "prod",
+		},
+		{
+			name:     "AWS_PROFILE naming an unknown profile is ignored",
+			profiles: []string{"default", "prod"},
+			envVar:   "gone",
+			want:     "default",
+		},
+		{
+			name:     "default is preferred when present",
+			profiles: []string{"acme", "default"},
+			want:     "default",
+		},
+		{
+			name:     "first profile otherwise",
+			profiles: []string{"acme", "prod"},
+			want:     "acme",
+		},
+		{
+			name:     "no profiles yields nothing",
+			profiles: nil,
+			want:     "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("AWS_PROFILE", tc.envVar)
+
+			assert.Equal(t, tc.want, preferredAWSProfile(tc.profiles))
+		})
+	}
+}
+
+// chooseAWSProfile only opens a form when there is more than one profile — the
+// no-profile and single-profile paths must settle without any input.
+func TestChooseAWSProfileNonInteractivePaths(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         string
+		credentials    string
+		cfg            *PromptedConfig
+		wantProfile    string
+		wantPromptKeys bool
+	}{
+		{
+			name:           "nothing in ~/.aws falls back to typing keys in",
+			wantPromptKeys: true,
+		},
+		{
+			name:        "a lone default profile is left to the SDK",
+			config:      "[default]\nregion = eu-west-1\n",
+			wantProfile: "",
+		},
+		{
+			name:        "a lone named profile is pinned, since there is no [default] to resolve",
+			credentials: "[work]\naws_access_key_id = A\n",
+			wantProfile: "work",
+		},
+		{
+			// Keys already in the config win at bootstrap, so naming a profile
+			// beside them would be a lie.
+			name:        "a lone named profile is not pinned over existing keys",
+			credentials: "[work]\naws_access_key_id = A\n",
+			cfg:         &PromptedConfig{AWSAccessKeyID: "AKIAEXISTING"},
+			wantProfile: "",
+		},
+		{
+			// The profile can no longer resolve — it must not survive.
+			name:           "a stale profile is dropped when ~/.aws is gone",
+			cfg:            &PromptedConfig{AWSProfile: "gone"},
+			wantProfile:    "",
+			wantPromptKeys: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			writeAWSFiles(t, tc.config, tc.credentials)
+
+			cfg := tc.cfg
+			if cfg == nil {
+				cfg = &PromptedConfig{}
 			}
+
+			promptForKeys, err := chooseAWSProfile(cfg)
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantPromptKeys, promptForKeys)
+			assert.Equal(t, tc.wantProfile, cfg.AWSProfile)
+		})
+	}
+}
+
+// Credentials exported in the shell are worth confirming rather than retyping,
+// but they must reach secrets.yaml : env vars last one shell session, and
+// `cluster bootstrap` needs them on every later run.
+func TestChooseAWSProfilePrefillsFromEnv(t *testing.T) {
+	tests := []struct {
+		name        string
+		credentials string
+		// resumed stands in for a secrets.yaml recovered from a previous run.
+		resumed          *PromptedConfig
+		wantPromptKeys   bool
+		wantAccessKeyID  string
+		wantSecretKey    string
+		wantSessionToken string
+	}{
+		{
+			name:             "no ~/.aws seeds the inputs from the environment",
+			wantPromptKeys:   true,
+			wantAccessKeyID:  "AKIAFROMENV",
+			wantSecretKey:    "env-secret",
+			wantSessionToken: "env-token",
+		},
+		{
+			name: "credentials already in the config win over the environment",
+			resumed: &PromptedConfig{
+				AWSAccessKeyID:     "AKIAFROMCONFIG",
+				AWSSecretAccessKey: "config-secret",
+			},
+			wantPromptKeys:  true,
+			wantAccessKeyID: "AKIAFROMCONFIG",
+			wantSecretKey:   "config-secret",
+			// Blank in the config, so the environment still fills this one in.
+			wantSessionToken: "env-token",
+		},
+		{
+			// A profile is chosen, so no keys are collected — seeding them
+			// would put keys in secrets.yaml that silently beat the profile.
+			name:           "a resolvable profile leaves the environment alone",
+			credentials:    "[work]\naws_access_key_id = A\n",
+			wantPromptKeys: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			writeAWSFiles(t, "", tc.credentials)
+			t.Setenv("AWS_ACCESS_KEY_ID", "AKIAFROMENV")
+			t.Setenv("AWS_SECRET_ACCESS_KEY", "env-secret")
+			t.Setenv("AWS_SESSION_TOKEN", "env-token")
+
+			cfg := tc.resumed
+			if cfg == nil {
+				cfg = &PromptedConfig{}
+			}
+
+			promptForKeys, err := chooseAWSProfile(cfg)
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantPromptKeys, promptForKeys)
+			assert.Equal(t, tc.wantAccessKeyID, cfg.AWSAccessKeyID)
+			assert.Equal(t, tc.wantSecretKey, cfg.AWSSecretAccessKey)
+			assert.Equal(t, tc.wantSessionToken, cfg.AWSSessionToken)
 		})
 	}
 }

--- a/pkg/config/prompt/render_secrets_test.go
+++ b/pkg/config/prompt/render_secrets_test.go
@@ -257,3 +257,70 @@ func TestRenderObmondoSupportConfig(t *testing.T) {
 	parsed := &config.SecretsConfig{}
 	require.NoError(t, yaml.Unmarshal(secretsBody, parsed))
 }
+
+// TestRenderSecretsAWSProfile covers the three shapes the aws: block can take.
+// A profile alone is the multi-account case from issue #87 : the keys stay in
+// ~/.aws and are resolved from the named profile at bootstrap, so secrets.yaml
+// must carry the profile and no keys.
+func TestRenderSecretsAWSProfile(t *testing.T) {
+	cases := []struct {
+		name           string
+		cfg            *PromptedConfig
+		wantContains   []string
+		wantNotContain []string
+	}{
+		{
+			name: "profile only",
+			cfg: &PromptedConfig{
+				CloudProvider: "aws",
+				AWSProfile:    "work",
+			},
+			wantContains:   []string{"aws:", `profile: "work"`},
+			wantNotContain: []string{"accessKeyID:", "secretAccessKey:"},
+		},
+		{
+			name: "credentials only",
+			cfg: &PromptedConfig{
+				CloudProvider:      "aws",
+				AWSAccessKeyID:     "AKIAFAKEEXAMPLE",
+				AWSSecretAccessKey: "fake/secret:key#1",
+				AWSSessionToken:    "fake-session-token",
+			},
+			wantContains:   []string{"aws:", `accessKeyID: "AKIAFAKEEXAMPLE"`},
+			wantNotContain: []string{"profile:"},
+		},
+		{
+			name: "neither renders no aws block",
+			cfg: &PromptedConfig{
+				CloudProvider: "aws",
+			},
+			wantNotContain: []string{"aws:"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			require.NoError(t, writeConfigFiles(dir, tc.cfg))
+
+			body, err := os.ReadFile(filepath.Join(dir, "secrets.yaml"))
+			require.NoError(t, err)
+
+			for _, want := range tc.wantContains {
+				assert.Contains(t, string(body), want, "raw bytes:\n%s", string(body))
+			}
+			for _, unwanted := range tc.wantNotContain {
+				assert.NotContains(t, string(body), unwanted, "raw bytes:\n%s", string(body))
+			}
+
+			parsed := &config.SecretsConfig{}
+			require.NoError(t, yaml.Unmarshal(body, parsed),
+				"rendered secrets.yaml must parse cleanly — raw bytes:\n%s", string(body))
+
+			if tc.cfg.AWSProfile != "" {
+				require.NotNil(t, parsed.AWS)
+				assert.Equal(t, tc.cfg.AWSProfile, parsed.AWS.Profile)
+			}
+		})
+	}
+}

--- a/pkg/config/prompt/resume.go
+++ b/pkg/config/prompt/resume.go
@@ -395,6 +395,7 @@ func applySecretsConfigToPromptedConfig(secrets *config.SecretsConfig, cfg *Prom
 	}
 
 	if secrets.AWS != nil {
+		cfg.AWSProfile = firstNonEmpty(secrets.AWS.Profile, cfg.AWSProfile)
 		cfg.AWSAccessKeyID = firstNonEmpty(secrets.AWS.AWSAccessKeyID, cfg.AWSAccessKeyID)
 		cfg.AWSSecretAccessKey = firstNonEmpty(secrets.AWS.AWSSecretAccessKey, cfg.AWSSecretAccessKey)
 		cfg.AWSSessionToken = firstNonEmpty(secrets.AWS.AWSSessionToken, cfg.AWSSessionToken)

--- a/pkg/config/secrets.go
+++ b/pkg/config/secrets.go
@@ -94,6 +94,19 @@ type (
 	}
 
 	AWSCredentials struct {
+		// Profile names the ~/.aws/{config,credentials} profile the
+		// credentials for this cluster are resolved from. Set it when the
+		// machine carries several AWS accounts and the SDK default profile
+		// is not the right one. Leave the key fields blank alongside it —
+		// they are filled in from the profile at parse time. Machine-local
+		// (profile names differ per operator), which is why it lives here
+		// and not in general.yaml.
+		Profile string `yaml:"profile"`
+
+		// AWSAccessKeyID, AWSSecretAccessKey and AWSSessionToken are the
+		// resolved credentials. Supply them directly to bypass ~/.aws
+		// entirely; otherwise leave them blank and they are resolved from
+		// Profile (or the SDK default profile when Profile is empty).
 		AWSAccessKeyID     string `yaml:"accessKeyID"     validate:"notblank"`
 		AWSSecretAccessKey string `yaml:"secretAccessKey" validate:"notblank"`
 		AWSSessionToken    string `yaml:"sessionToken"`

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -15,11 +15,25 @@ const (
 	EnvNameSSHAuthSock   = "SSH_AUTH_SOCK"
 	EnvNameSSHKnownHosts = "SSH_KNOWN_HOSTS"
 
-	EnvNameAWSAccessKey            = "AWS_ACCESS_KEY_ID"
-	EnvNameAWSSecretKey            = "AWS_SECRET_ACCESS_KEY"
-	EnvNameAWSSessionToken         = "AWS_SESSION_TOKEN"
-	EnvNameAWSRegion               = "AWS_REGION"
-	EnvNameAWSB64EcodedCredentials = "AWS_B64ENCODED_CREDENTIALS"
+	EnvNameAWSAccessKey    = "AWS_ACCESS_KEY_ID"
+	EnvNameAWSSecretKey    = "AWS_SECRET_ACCESS_KEY"
+	EnvNameAWSSessionToken = "AWS_SESSION_TOKEN"
+	EnvNameAWSRegion       = "AWS_REGION"
+	// EnvNameAWSProfile points the embedded clusterawsadm commands, which
+	// build their own AWS SDK config, at the same profile as the rest of the
+	// run — and clears a stale one inherited from the operator's shell.
+	//
+	// Their credentials come from the static keys exported alongside this:
+	// an env-var profile does NOT outrank env-var credentials (only a
+	// programmatic WithSharedConfigProfile does). What this settles is the
+	// rest of the shared config those commands read.
+	EnvNameAWSProfile = "AWS_PROFILE"
+	// EnvNameAWSConfigFile and EnvNameAWSSharedCredentialsFile relocate the
+	// two ~/.aws files. Read when listing the profiles to choose between, so
+	// a direnv-style setup pointing elsewhere is seen.
+	EnvNameAWSConfigFile            = "AWS_CONFIG_FILE"
+	EnvNameAWSSharedCredentialsFile = "AWS_SHARED_CREDENTIALS_FILE"
+	EnvNameAWSB64EcodedCredentials  = "AWS_B64ENCODED_CREDENTIALS"
 
 	EnvNameHCloudToken   = "HCLOUD_TOKEN"
 	EnvNameRobotUser     = "ROBOT_USER"

--- a/pkg/core/recover_cluster.go
+++ b/pkg/core/recover_cluster.go
@@ -8,9 +8,9 @@ import (
 	"log/slog"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
-	awsSDKGoV2Config "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 
+	awsCloudProvider "github.com/Obmondo/kubeaid-cli/pkg/cloud/aws"
 	awsServices "github.com/Obmondo/kubeaid-cli/pkg/cloud/aws/services"
 	"github.com/Obmondo/kubeaid-cli/pkg/cloud/azure"
 	"github.com/Obmondo/kubeaid-cli/pkg/config"
@@ -51,7 +51,7 @@ func RecoverCluster(ctx context.Context, managementClusterName string, skipPRWor
 
 	switch globals.CloudProviderName {
 	case constants.CloudProviderAWS:
-		awsSDKConfig, err := awsSDKGoV2Config.LoadDefaultConfig(ctx)
+		awsSDKConfig, err := awsCloudProvider.LoadSDKConfig(ctx)
 		assert.AssertErrNil(ctx, err, "Failed initiating AWS SDK config")
 
 		s3Client := s3.NewFromConfig(awsSDKConfig)

--- a/pkg/render/config.go
+++ b/pkg/render/config.go
@@ -138,11 +138,15 @@ type PromptedConfig struct {
 	AWSNodeInstanceType string
 	// AWSNodeAMIID is the worker node-group AMI, resolved for the worker
 	// instance type's architecture (AWSAMIID is the control plane's).
-	AWSNodeAMIID       string
-	AWSSSHKeyName      string
-	AWSCPInstanceType  string
-	AWSCPReplicas      string
-	AWSAMIID           string
+	AWSNodeAMIID      string
+	AWSSSHKeyName     string
+	AWSCPInstanceType string
+	AWSCPReplicas     string
+	AWSAMIID          string
+	// AWSProfile is the ~/.aws profile this cluster's credentials are read
+	// from. Only set when the machine carries more than one profile and the
+	// operator picked one; empty means the SDK default profile.
+	AWSProfile         string
 	AWSAccessKeyID     string
 	AWSSecretAccessKey string
 	AWSSessionToken    string

--- a/pkg/render/templates/secrets.yaml.tmpl
+++ b/pkg/render/templates/secrets.yaml.tmpl
@@ -5,12 +5,20 @@
        which YAML would otherwise treat as a comment and turn
        `user: #abc` into `user:` (blank value) — failing the
        Robot.User notblank validator at bootstrap. */ -}}
+{{- /* The aws block carries either a profile name (credentials stay in
+       ~/.aws and are resolved from that profile at bootstrap) or the
+       credentials themselves. Neither means the SDK's default profile. */ -}}
 {{- if eq .CloudProvider "aws" }}
-{{- if .AWSAccessKeyID }}
+{{- if or .AWSProfile .AWSAccessKeyID }}
 aws:
+{{- if .AWSProfile }}
+  profile: {{ printf "%q" .AWSProfile }}
+{{- end }}
+{{- if .AWSAccessKeyID }}
   accessKeyID: {{ printf "%q" .AWSAccessKeyID }}
   secretAccessKey: {{ printf "%q" .AWSSecretAccessKey }}
   sessionToken: {{ printf "%q" .AWSSessionToken }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- if eq .CloudProvider "azure" }}


### PR DESCRIPTION
… from

There was no way to record which AWS profile a cluster belongs to: credentials came from whatever the SDK resolved by default, so anyone managing several accounts had to rewrite ~/.aws to bootstrap a cluster and rewrite it back afterwards. secrets.yaml can now name the profile:

    aws:
      profile: acme-prod

config generate fills it in, asking which account the cluster belongs to when ~/.aws holds more than one profile, and skipping the key inputs once one is chosen. It lives in secrets.yaml, not general.yaml, because profile names are machine-local.

Precedence at bootstrap: keys in secrets.yaml win outright, else aws.profile, else the SDK's own default resolution as before. A config never carries both, since the keys would win and the profile would be a lie.

Profile detection also replaces the old "does either ~/.aws file exist" check, so an ~/.aws that exists but holds no usable profile now prompts at generate time instead of failing much later at bootstrap with a five-second EC2 IMDS timeout.

Closes #87.